### PR TITLE
Reorder credential chain for environment variables

### DIFF
--- a/provider.go
+++ b/provider.go
@@ -139,8 +139,8 @@ func awsHttpClient(region string, d *schema.ResourceData) *http.Client {
 				SessionToken:    d.Get("aws_token").(string),
 			},
 		},
-		&awscredentials.SharedCredentialsProvider{},
 		&awscredentials.EnvProvider{},
+		&awscredentials.SharedCredentialsProvider{},
 	})
 	signer := awssigv4.NewSigner(creds)
 	client, _ := aws_signing_client.New(signer, nil, "es", region)


### PR DESCRIPTION
Currently, environment variables will not be used for AWS credentials if a shared credential file exists. This change updates the elasticsearch provider to use the same order of precedence as the [AWS CLI](https://docs.aws.amazon.com/cli/latest/userguide/cli-chap-configure.html).