### PR TITLE
Add support for AWS ec2 role credentials

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/hashicorp/terraform-plugin-sdk v1.0.0
 	github.com/olivere/elastic v6.2.26+incompatible
 	github.com/olivere/elastic/v7 v7.0.9
+	github.com/stretchr/objx v0.1.1 // indirect
 	gopkg.in/olivere/elastic.v5 v5.0.82
 	gopkg.in/olivere/elastic.v6 v6.2.23
 )

--- a/provider.go
+++ b/provider.go
@@ -11,6 +11,9 @@ import (
 	"regexp"
 
 	awscredentials "github.com/aws/aws-sdk-go/aws/credentials"
+	awsec2rolecreds "github.com/aws/aws-sdk-go/aws/credentials/ec2rolecreds"
+	awsec2metadata "github.com/aws/aws-sdk-go/aws/ec2metadata"
+	awssession "github.com/aws/aws-sdk-go/aws/session"
 	awssigv4 "github.com/aws/aws-sdk-go/aws/signer/v4"
 	"github.com/deoxxa/aws_signing_client"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/pathorcontents"
@@ -255,6 +258,9 @@ func awsHttpClient(region string, d *schema.ResourceData) *http.Client {
 		},
 		&awscredentials.EnvProvider{},
 		&awscredentials.SharedCredentialsProvider{},
+		&awsec2rolecreds.EC2RoleProvider{
+			Client: awsec2metadata.New(awssession.Must(awssession.NewSession())),
+		},
 	})
 	signer := awssigv4.NewSigner(creds)
 	client, _ := aws_signing_client.New(signer, nil, "es", region)


### PR DESCRIPTION
The current auth methods for getting signing creds for AWS elasticsearch don't include getting the ec2 role creds which is the standard auth mechanism if the script is running on an AWS instance.

The main terraform-aws-provider does support this method along with the others.

This PR adds support and I can now run terraform with elasticsearch provider from my CI slave running on an EC2 instance.

This is the first time I've touched golang so please feel free to provide constructive criticism. 