### PR TITLE
Import users and role mappings

### DIFF
--- a/resource_elasticsearch_xpack_role_mapping.go
+++ b/resource_elasticsearch_xpack_role_mapping.go
@@ -50,7 +50,7 @@ func resourceElasticsearchXpackRoleMapping() *schema.Resource {
 			},
 		},
 		Importer: &schema.ResourceImporter{
-		  State: schema.ImportStatePassthrough,
+			State: schema.ImportStatePassthrough,
 		},
 	}
 }

--- a/resource_elasticsearch_xpack_role_mapping.go
+++ b/resource_elasticsearch_xpack_role_mapping.go
@@ -49,6 +49,9 @@ func resourceElasticsearchXpackRoleMapping() *schema.Resource {
 				DiffSuppressFunc: suppressEquivalentJson,
 			},
 		},
+		Importer: &schema.ResourceImporter{
+		  State: schema.ImportStatePassthrough,
+		},
 	}
 }
 

--- a/resource_elasticsearch_xpack_role_mapping_test.go
+++ b/resource_elasticsearch_xpack_role_mapping_test.go
@@ -235,7 +235,7 @@ func TestAccRoleMappingResource_importBasic(t *testing.T) {
 	randomName := "test" + acctest.RandStringFromCharSet(10, acctest.CharSetAlpha)
 
 	resource.Test(t, resource.TestCase{
-                PreCheck: func() {
+		PreCheck: func() {
 			testAccPreCheck(t)
 			if !allowed {
 				t.Skip("Role Mappings only supported on ES >= 6")
@@ -248,10 +248,10 @@ func TestAccRoleMappingResource_importBasic(t *testing.T) {
 				Config: testAccRoleMappingResource(randomName),
 			},
 			{
-				ResourceName:      "elasticsearch_xpack_role_mapping.test",
-				ImportState:       true,
-				ImportStateVerify: true,
-                                ImportStateVerifyIgnore: []string{"role_mapping_name"}, // we either found it by name or it's not there
+				ResourceName:            "elasticsearch_xpack_role_mapping.test",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"role_mapping_name"}, // we either found it by name or it's not there
 			},
 		},
 	})

--- a/resource_elasticsearch_xpack_role_mapping_test.go
+++ b/resource_elasticsearch_xpack_role_mapping_test.go
@@ -216,3 +216,43 @@ resource "elasticsearch_xpack_role_mapping" "test" {
 }
 `, resourceName)
 }
+
+func TestAccRoleMappingResource_importBasic(t *testing.T) {
+	provider := Provider().(*schema.Provider)
+	err := provider.Configure(&terraform.ResourceConfig{})
+	if err != nil {
+		t.Skipf("err: %s", err)
+	}
+	meta := provider.Meta()
+	var allowed bool
+	switch meta.(type) {
+	case *elastic5.Client:
+		allowed = false
+	default:
+		allowed = true
+	}
+
+	randomName := "test" + acctest.RandStringFromCharSet(10, acctest.CharSetAlpha)
+
+	resource.Test(t, resource.TestCase{
+                PreCheck: func() {
+			testAccPreCheck(t)
+			if !allowed {
+				t.Skip("Role Mappings only supported on ES >= 6")
+			}
+		},
+		Providers:    testAccXPackProviders,
+		CheckDestroy: testAccCheckRoleMappingDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccRoleMappingResource(randomName),
+			},
+			{
+				ResourceName:      "elasticsearch_xpack_role_mapping.test",
+				ImportState:       true,
+				ImportStateVerify: true,
+                                ImportStateVerifyIgnore: []string{"role_mapping_name"}, // we either found it by name or it's not there
+			},
+		},
+	})
+}

--- a/resource_elasticsearch_xpack_user.go
+++ b/resource_elasticsearch_xpack_user.go
@@ -74,6 +74,9 @@ func resourceElasticsearchXpackUser() *schema.Resource {
 				DiffSuppressFunc: suppressEquivalentJson,
 			},
 		},
+		Importer: &schema.ResourceImporter{
+		  State: schema.ImportStatePassthrough,
+		},
 	}
 }
 

--- a/resource_elasticsearch_xpack_user.go
+++ b/resource_elasticsearch_xpack_user.go
@@ -75,7 +75,7 @@ func resourceElasticsearchXpackUser() *schema.Resource {
 			},
 		},
 		Importer: &schema.ResourceImporter{
-		  State: schema.ImportStatePassthrough,
+			State: schema.ImportStatePassthrough,
 		},
 	}
 }

--- a/resource_elasticsearch_xpack_user_test.go
+++ b/resource_elasticsearch_xpack_user_test.go
@@ -179,3 +179,45 @@ resource "elasticsearch_xpack_user" "test" {
 }
 `, resourceName)
 }
+
+func TestAccUserResource_importBasic(t *testing.T) {
+	provider := Provider().(*schema.Provider)
+	err := provider.Configure(&terraform.ResourceConfig{})
+	if err != nil {
+		t.Skipf("err: %s", err)
+	}
+	meta := provider.Meta()
+	var allowed bool
+	switch meta.(type) {
+	case *elastic5.Client:
+		allowed = false
+	case *elastic6.Client:
+		allowed = false
+	default:
+		allowed = true
+	}
+
+	randomName := "test" + acctest.RandStringFromCharSet(10, acctest.CharSetAlpha)
+
+	resource.Test(t, resource.TestCase{
+                PreCheck: func() {
+			testAccPreCheck(t)
+			if !allowed {
+				t.Skip("Users only supported on ES >= 6")
+			}
+		},
+		Providers:    testAccXPackProviders,
+		CheckDestroy: testAccCheckUserDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccUserResource(randomName),
+			},
+			{
+				ResourceName:      "elasticsearch_xpack_user.test",
+				ImportState:       true,
+				ImportStateVerify: true,
+                                ImportStateVerifyIgnore: []string{"password"}, // because ES doesn't return this field
+			},
+		},
+	})
+}

--- a/resource_elasticsearch_xpack_user_test.go
+++ b/resource_elasticsearch_xpack_user_test.go
@@ -200,7 +200,7 @@ func TestAccUserResource_importBasic(t *testing.T) {
 	randomName := "test" + acctest.RandStringFromCharSet(10, acctest.CharSetAlpha)
 
 	resource.Test(t, resource.TestCase{
-                PreCheck: func() {
+		PreCheck: func() {
 			testAccPreCheck(t)
 			if !allowed {
 				t.Skip("Users only supported on ES >= 6")
@@ -213,10 +213,10 @@ func TestAccUserResource_importBasic(t *testing.T) {
 				Config: testAccUserResource(randomName),
 			},
 			{
-				ResourceName:      "elasticsearch_xpack_user.test",
-				ImportState:       true,
-				ImportStateVerify: true,
-                                ImportStateVerifyIgnore: []string{"password"}, // because ES doesn't return this field
+				ResourceName:            "elasticsearch_xpack_user.test",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"password"}, // because ES doesn't return this field
 			},
 		},
 	})


### PR DESCRIPTION
Intended to close https://github.com/phillbaker/terraform-provider-elasticsearch/issues/57

Currently a WIP.

Users and Role-Mappings can be imported successfully, and the tests pass.

With Roles, however, the tests currently fail with:

```
=== RUN   TestAccRoleResource_importBasic
--- FAIL: TestAccRoleResource_importBasic (0.13s)
    testing.go:569: Step 1 error: ImportStateVerify attributes not equivalent. Difference is shown below. Top is actual, bottom is expected.

        (map[string]string) {
        }


        (map[string]string) (len=20) {
         (string) (len=14) "applications.#": (string) (len=1) "1",
         (string) (len=34) "applications.874600885.application": (string) (len=7) "testapp",
         (string) (len=35) "applications.874600885.privileges.#": (string) (len=1) "2",
         (string) (len=44) "applications.874600885.privileges.2560631222": (string) (len=5) "write",
         (string) (len=44) "applications.874600885.privileges.2957485331": (string) (len=4) "read",
         (string) (len=34) "applications.874600885.resources.#": (string) (len=1) "1",
         (string) (len=43) "applications.874600885.resources.2679715827": (string) (len=1) "*",
         (string) (len=9) "indices.#": (string) (len=1) "2",
         (string) (len=33) "indices.3102539583.field_security": (string) (len=2) "{}",
         (string) (len=26) "indices.3102539583.names.#": (string) (len=1) "1",
         (string) (len=34) "indices.3102539583.names.482586785": (string) (len=11) "testIndice2",
         (string) (len=31) "indices.3102539583.privileges.#": (string) (len=1) "1",
         (string) (len=40) "indices.3102539583.privileges.2560631222": (string) (len=5) "write",
         (string) (len=24) "indices.3102539583.query": (string) (len=2) "{}",
         (string) (len=32) "indices.673947817.field_security": (string) (len=2) "{}",
         (string) (len=25) "indices.673947817.names.#": (string) (len=1) "1",
         (string) (len=34) "indices.673947817.names.3647409128": (string) (len=10) "testIndice",
         (string) (len=30) "indices.673947817.privileges.#": (string) (len=1) "1",
         (string) (len=39) "indices.673947817.privileges.2957485331": (string) (len=4) "read",
         (string) (len=23) "indices.673947817.query": (string) (len=2) "{}"
        }
```

As near as I can tell, this is because the `indices` and `applications` attributes are not getting saved to the terraform state, currently. Hence the tests I added in https://github.com/phillbaker/terraform-provider-elasticsearch/commit/9d42ff1f0357e881de3a796223e349f7b6c60c4e, to verify this is indeed the case.

I'm not too familiar with golang, so I'm not sure where to go from here. I feel like the `indices` and `applications` attributes _should_ be saved to tf state, but perhaps I'm missing something? And if they should, I'm not certain how to go about making sure they are.