### PR TITLE
Add aws profile authentication option

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,6 +167,17 @@ $ export AWS_SECRET_ACCESS_KEY="asecretkey"
 $ terraform plan
 ```
 
+#### AWS profile
+
+You can specify a named profile that will be used for credentials (either static, or sts assumed role creds).  eg:
+
+```tf
+provider "elasticsearch" {
+    url         = "https://search-foo-bar-pqrhr4w3u4dzervg41frow4mmy.us-east-1.es.amazonaws.com"
+    aws_profile = "profilename"
+}
+```
+
 #### Shared Credentials file
 
 You can use an AWS credentials file to specify your credentials. The default location is `$HOME/.aws/credentials` on Linux and macOS, or `%USERPROFILE%\.aws\credentials` for Windows users.

--- a/es/provider.go
+++ b/es/provider.go
@@ -10,9 +10,8 @@ import (
 	"net/url"
 	"regexp"
 
+	"github.com/aws/aws-sdk-go/aws"
 	awscredentials "github.com/aws/aws-sdk-go/aws/credentials"
-	awsec2rolecreds "github.com/aws/aws-sdk-go/aws/credentials/ec2rolecreds"
-	awsec2metadata "github.com/aws/aws-sdk-go/aws/ec2metadata"
 	awssession "github.com/aws/aws-sdk-go/aws/session"
 	awssigv4 "github.com/aws/aws-sdk-go/aws/signer/v4"
 	"github.com/deoxxa/aws_signing_client"
@@ -257,21 +256,30 @@ func providerConfigure(d *schema.ResourceData) (interface{}, error) {
 }
 
 func awsHttpClient(region string, d *schema.ResourceData) *http.Client {
-	creds := awscredentials.NewChainCredentials([]awscredentials.Provider{
-		&awscredentials.StaticProvider{
-			Value: awscredentials.Value{
-				AccessKeyID:     d.Get("aws_access_key").(string),
-				SecretAccessKey: d.Get("aws_secret_key").(string),
-				SessionToken:    d.Get("aws_token").(string),
-			},
+	aws_access_key_id := d.Get("aws_access_key").(string)
+	aws_secret_access_key := d.Get("aws_secret_key").(string)
+	aws_session_token := d.Get("aws_token").(string)
+	aws_profile := d.Get("aws_profile").(string)
+
+	sessOpts := awssession.Options{
+		Config: aws.Config{
+			Region: aws.String(region),
 		},
-		&awscredentials.EnvProvider{},
-		&awscredentials.SharedCredentialsProvider{},
-		&awsec2rolecreds.EC2RoleProvider{
-			Client: awsec2metadata.New(awssession.Must(awssession.NewSession())),
-		},
-	})
-	signer := awssigv4.NewSigner(creds)
+	}
+	// 1. access keys take priority
+	// 2. next is a profile (for assume role)
+	// 3. let the default credentials provider figure out the rest (env, ec2, etc..)
+	//
+	// note: if #1 is chosen, then no further providers will be tested, since we've overridden the credentials with just a static provider
+	if aws_access_key_id != "" {
+		sessOpts.Config.Credentials = awscredentials.NewStaticCredentials(aws_access_key_id, aws_secret_access_key, aws_session_token)
+	} else if aws_profile != "" {
+		sessOpts.Profile = aws_profile
+	}
+
+	sess := awssession.Must(awssession.NewSessionWithOptions(sessOpts))
+
+	signer := awssigv4.NewSigner(sess.Config.Credentials)
 	client, _ := aws_signing_client.New(signer, nil, "es", region)
 
 	return client

--- a/es/provider.go
+++ b/es/provider.go
@@ -80,6 +80,13 @@ func Provider() terraform.ResourceProvider {
 				Description: "The session token for use with AWS Elasticsearch Service domains",
 			},
 
+			"aws_profile": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Default:     "",
+				Description: "The AWS profile for use with AWS Elasticsearch Service domains",
+			},
+
 			"cacert_file": {
 				Type:        schema.TypeString,
 				Optional:    true,

--- a/es/provider.go
+++ b/es/provider.go
@@ -255,7 +255,7 @@ func providerConfigure(d *schema.ResourceData) (interface{}, error) {
 	return relevantClient, nil
 }
 
-func awsHttpClient(region string, d *schema.ResourceData) *http.Client {
+func awsSession(region string, d *schema.ResourceData) *awssession.Session {
 	aws_access_key_id := d.Get("aws_access_key").(string)
 	aws_secret_access_key := d.Get("aws_secret_key").(string)
 	aws_session_token := d.Get("aws_token").(string)
@@ -277,9 +277,11 @@ func awsHttpClient(region string, d *schema.ResourceData) *http.Client {
 		sessOpts.Profile = aws_profile
 	}
 
-	sess := awssession.Must(awssession.NewSessionWithOptions(sessOpts))
+	return awssession.Must(awssession.NewSessionWithOptions(sessOpts))
+}
 
-	signer := awssigv4.NewSigner(sess.Config.Credentials)
+func awsHttpClient(region string, d *schema.ResourceData) *http.Client {
+	signer := awssigv4.NewSigner(awsSession(region, d).Config.Credentials)
 	client, _ := aws_signing_client.New(signer, nil, "es", region)
 
 	return client

--- a/es/provider_test.go
+++ b/es/provider_test.go
@@ -69,20 +69,25 @@ func testAccPreCheck(t *testing.T) {
 	}
 }
 
-func TestAWSCreds(t *testing.T) {
+// Given:
+// 1. AWS credentials are specified via environment variables
+// 2. aws access key and secret access key are specified via the provider configuration
+// 3. a named profile is specified via the provider config
+//
+// this tests that:  the configured provider access key / secret key are used over the other options (ie: #2)
+func TestAWSCredsManualKey(t *testing.T) {
+	envAccessKeyID := "ENV_ACCESS_KEY"
 	testRegion := "us-east-1"
 	manualAccessKeyID := "MANUAL_ACCESS_KEY"
-	envAccessKeyID := "ENV_ACCESS_KEY"
-	profileAccessKeyID := "PROFILE_ACCESS_KEY"
+	namedProfile := "testing"
 
-	os.Setenv("AWS_CONFIG_FILE", "../test_aws_config")
 	os.Setenv("AWS_ACCESS_KEY_ID", envAccessKeyID)
 	os.Setenv("AWS_SECRET_ACCESS_KEY", "ENV_SECRET")
 
 	// first, check that if we set aws_profile with aws_access_key_id - the latter takes precedence
 	testConfig := map[string]interface{}{
-		"aws_profile":    "testing",
-		"aws_access_key": "MANUAL_ACCESS_KEY",
+		"aws_profile":    namedProfile,
+		"aws_access_key": manualAccessKeyID,
 		"aws_secret_key": "MANUAL_SECRET_KEY",
 	}
 
@@ -91,26 +96,80 @@ func TestAWSCreds(t *testing.T) {
 	if creds.AccessKeyID != manualAccessKeyID {
 		t.Errorf("access key id should have been %s (we got %s)", manualAccessKeyID, creds.AccessKeyID)
 	}
+}
 
-	// Now get rid of the manual access keys, and ensure that the profile is used
-	testConfig = map[string]interface{}{
-		"aws_profile": "testing",
+// Given:
+// 1. AWS credentials are specified via environment variables
+// 2. a named profile is specified via the provider config
+//
+// this tests that:  the named profile credentials are used over the env vars
+func TestAWSCredsNamedProfile(t *testing.T) {
+	envAccessKeyID := "ENV_ACCESS_KEY"
+	testRegion := "us-east-1"
+	namedProfile := "testing"
+	profileAccessKeyID := "PROFILE_ACCESS_KEY"
+
+	os.Setenv("AWS_CONFIG_FILE", "../test_aws_config") // set config file so we can ensure the profile we want to test exists
+	os.Setenv("AWS_ACCESS_KEY_ID", envAccessKeyID)
+	os.Setenv("AWS_SECRET_ACCESS_KEY", "ENV_SECRET")
+
+	testConfig := map[string]interface{}{
+		"aws_profile": namedProfile,
 	}
 
-	creds = getCreds(t, testRegion, testConfig)
+	creds := getCreds(t, testRegion, testConfig)
 
 	if creds.AccessKeyID != profileAccessKeyID {
 		t.Errorf("access key id should have been %s (we got %s)", profileAccessKeyID, creds.AccessKeyID)
 	}
 
-	// Now try without anything - it should use the default creds provider and pickup the env variables
-	testConfig = map[string]interface{}{}
+	os.Unsetenv("AWS_ACCESS_KEY_ID")
+	os.Unsetenv("AWS_SECRET_ACCESS_KEY")
+	os.Unsetenv("AWS_CONFIG_FILE")
+}
 
-	creds = getCreds(t, testRegion, testConfig)
+// Given:
+// 1. AWS credentials are specified via environment variables
+// 2. No configuration provided to the provider
+//
+// This tests that: we get the credentials from the environment variables (ie: from the default credentials provider chain)
+
+func TestAWSCredsEnv(t *testing.T) {
+	envAccessKeyID := "ENV_ACCESS_KEY"
+	testRegion := "us-east-1"
+
+	os.Setenv("AWS_ACCESS_KEY_ID", envAccessKeyID)
+	os.Setenv("AWS_SECRET_ACCESS_KEY", "ENV_SECRET")
+
+	testConfig := map[string]interface{}{}
+
+	creds := getCreds(t, testRegion, testConfig)
 
 	if creds.AccessKeyID != envAccessKeyID {
 		t.Errorf("access key id should have been %s (we got %s)", envAccessKeyID, creds.AccessKeyID)
 	}
+
+	os.Unsetenv("AWS_ACCESS_KEY_ID")
+	os.Unsetenv("AWS_SECRET_ACCESS_KEY")
+}
+
+func TestAWSCredsEnvNamedProfile(t *testing.T) {
+	namedProfile := "testing"
+	testRegion := "us-east-1"
+	profileAccessKeyID := "PROFILE_ACCESS_KEY"
+
+	os.Setenv("AWS_PROFILE", namedProfile)
+	os.Setenv("AWS_CONFIG_FILE", "../test_aws_config") // set config file so we can ensure the profile we want to test exists
+
+	testConfig := map[string]interface{}{}
+
+	creds := getCreds(t, testRegion, testConfig)
+
+	if creds.AccessKeyID != profileAccessKeyID {
+		t.Errorf("access key id should have been %s (we got %s)", profileAccessKeyID, creds.AccessKeyID)
+	}
+	os.Unsetenv("AWS_PROFILE")
+	os.Unsetenv("AWS_CONFIG_FILE")
 }
 
 func getCreds(t *testing.T, region string, config map[string]interface{}) credentials.Value {

--- a/es/provider_test.go
+++ b/es/provider_test.go
@@ -75,7 +75,7 @@ func TestAWSCreds(t *testing.T) {
 	envAccessKeyID := "ENV_ACCESS_KEY"
 	profileAccessKeyID := "PROFILE_ACCESS_KEY"
 
-	os.Setenv("AWS_CONFIG_FILE", "./test_aws_config")
+	os.Setenv("AWS_CONFIG_FILE", "../test_aws_config")
 	os.Setenv("AWS_ACCESS_KEY_ID", envAccessKeyID)
 	os.Setenv("AWS_SECRET_ACCESS_KEY", "ENV_SECRET")
 

--- a/es/provider_test.go
+++ b/es/provider_test.go
@@ -110,6 +110,7 @@ func TestAWSCredsNamedProfile(t *testing.T) {
 	profileAccessKeyID := "PROFILE_ACCESS_KEY"
 
 	os.Setenv("AWS_CONFIG_FILE", "../test_aws_config") // set config file so we can ensure the profile we want to test exists
+	os.Setenv("AWS_SDK_LOAD_CONFIG", "1")
 	os.Setenv("AWS_ACCESS_KEY_ID", envAccessKeyID)
 	os.Setenv("AWS_SECRET_ACCESS_KEY", "ENV_SECRET")
 
@@ -126,6 +127,7 @@ func TestAWSCredsNamedProfile(t *testing.T) {
 	os.Unsetenv("AWS_ACCESS_KEY_ID")
 	os.Unsetenv("AWS_SECRET_ACCESS_KEY")
 	os.Unsetenv("AWS_CONFIG_FILE")
+	os.Unsetenv("AWS_SDK_LOAD_CONFIG")
 }
 
 // Given:
@@ -159,6 +161,7 @@ func TestAWSCredsEnvNamedProfile(t *testing.T) {
 	profileAccessKeyID := "PROFILE_ACCESS_KEY"
 
 	os.Setenv("AWS_PROFILE", namedProfile)
+	os.Setenv("AWS_SDK_LOAD_CONFIG", "1")
 	os.Setenv("AWS_CONFIG_FILE", "../test_aws_config") // set config file so we can ensure the profile we want to test exists
 
 	testConfig := map[string]interface{}{}
@@ -170,6 +173,7 @@ func TestAWSCredsEnvNamedProfile(t *testing.T) {
 	}
 	os.Unsetenv("AWS_PROFILE")
 	os.Unsetenv("AWS_CONFIG_FILE")
+	os.Unsetenv("AWS_SDK_LOAD_CONFIG")
 }
 
 func getCreds(t *testing.T, region string, config map[string]interface{}) credentials.Value {

--- a/es/provider_test.go
+++ b/es/provider_test.go
@@ -4,6 +4,7 @@ import (
 	"os"
 	"testing"
 
+	"github.com/aws/aws-sdk-go/aws/credentials"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/terraform"
 )
@@ -66,4 +67,61 @@ func testAccPreCheck(t *testing.T) {
 	if v := os.Getenv("ELASTICSEARCH_URL"); v == "" {
 		t.Fatal("ELASTICSEARCH_URL must be set for acceptance tests")
 	}
+}
+
+func TestAWSCreds(t *testing.T) {
+	testRegion := "us-east-1"
+	manualAccessKeyID := "MANUAL_ACCESS_KEY"
+	envAccessKeyID := "ENV_ACCESS_KEY"
+	profileAccessKeyID := "PROFILE_ACCESS_KEY"
+
+	os.Setenv("AWS_CONFIG_FILE", "./test_aws_config")
+	os.Setenv("AWS_ACCESS_KEY_ID", envAccessKeyID)
+	os.Setenv("AWS_SECRET_ACCESS_KEY", "ENV_SECRET")
+
+	// first, check that if we set aws_profile with aws_access_key_id - the latter takes precedence
+	testConfig := map[string]interface{}{
+		"aws_profile":    "testing",
+		"aws_access_key": "MANUAL_ACCESS_KEY",
+		"aws_secret_key": "MANUAL_SECRET_KEY",
+	}
+
+	creds := getCreds(t, testRegion, testConfig)
+
+	if creds.AccessKeyID != manualAccessKeyID {
+		t.Errorf("access key id should have been %s (we got %s)", manualAccessKeyID, creds.AccessKeyID)
+	}
+
+	// Now get rid of the manual access keys, and ensure that the profile is used
+	testConfig = map[string]interface{}{
+		"aws_profile": "testing",
+	}
+
+	creds = getCreds(t, testRegion, testConfig)
+
+	if creds.AccessKeyID != profileAccessKeyID {
+		t.Errorf("access key id should have been %s (we got %s)", profileAccessKeyID, creds.AccessKeyID)
+	}
+
+	// Now try without anything - it should use the default creds provider and pickup the env variables
+	testConfig = map[string]interface{}{}
+
+	creds = getCreds(t, testRegion, testConfig)
+
+	if creds.AccessKeyID != envAccessKeyID {
+		t.Errorf("access key id should have been %s (we got %s)", envAccessKeyID, creds.AccessKeyID)
+	}
+}
+
+func getCreds(t *testing.T, region string, config map[string]interface{}) credentials.Value {
+	testConfigData := schema.TestResourceDataRaw(t, Provider().(*schema.Provider).Schema, config)
+	s := awsSession(region, testConfigData)
+	if s == nil {
+		t.Fatalf("awsSession returned nil")
+	}
+	creds, err := s.Config.Credentials.Get()
+	if err != nil {
+		t.Fatalf("Failed fetching credentials: %v", err)
+	}
+	return creds
 }

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,6 @@ require (
 	github.com/hashicorp/terraform-plugin-sdk v1.0.0
 	github.com/olivere/elastic v6.2.26+incompatible
 	github.com/olivere/elastic/v7 v7.0.9
-	github.com/stretchr/objx v0.1.1 // indirect
 	gopkg.in/olivere/elastic.v5 v5.0.82
 	gopkg.in/olivere/elastic.v6 v6.2.23
 )

--- a/go.sum
+++ b/go.sum
@@ -20,6 +20,7 @@ github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRF
 github.com/apache/thrift v0.12.0/go.mod h1:cp2SuWMxlEZw2r+iP2GNCdIi4C1qmUzdZFSVb+bacwQ=
 github.com/apparentlymart/go-cidr v1.0.1 h1:NmIwLZ/KdsjIUlhf+/Np40atNXm/+lZ5txfTJ/SpF+U=
 github.com/apparentlymart/go-cidr v1.0.1/go.mod h1:EBcsNrHc3zQeuaeCeCtQruQm+n9/YjEn/vI25Lg7Gwc=
+github.com/apparentlymart/go-dump v0.0.0-20180507223929-23540a00eaa3 h1:ZSTrOEhiM5J5RFxEaFvMZVEAM1KvT1YzbEOwB2EAGjA=
 github.com/apparentlymart/go-dump v0.0.0-20180507223929-23540a00eaa3/go.mod h1:oL81AME2rN47vu18xqj1S1jPIPuN7afo62yKTNn3XMM=
 github.com/apparentlymart/go-textseg v1.0.0 h1:rRmlIsPEEhUTIKQb7T++Nz/A5Q6C9IuX2wFoYVvnCs0=
 github.com/apparentlymart/go-textseg v1.0.0/go.mod h1:z96Txxhf3xSFMPmb5X/1W05FF/Nj9VFpLOpjS5yuumk=
@@ -59,6 +60,7 @@ github.com/go-test/deep v1.0.3 h1:ZrJSEWsXzPOxaZnFteGEfooLba+ju3FYIbOrS+rQd68=
 github.com/go-test/deep v1.0.3/go.mod h1:wGDj63lr65AM2AQyKZd/NYHGb0R+1RLqB8NKt3aSFNA=
 github.com/gogo/protobuf v1.1.1/go.mod h1:r8qH/GZQm5c6nD/R0oafs1akxWv10x8SbQlK7atdtwQ=
 github.com/gogo/protobuf v1.2.0/go.mod h1:r8qH/GZQm5c6nD/R0oafs1akxWv10x8SbQlK7atdtwQ=
+github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b h1:VKtxabqXZkF25pY9ekfRL6a582T4P37/31XEstQ5p58=
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b/go.mod h1:SBH7ygxi8pfUlaOkMMuAQtPIUF8ecWP5IEl/CR7VP2Q=
 github.com/golang/groupcache v0.0.0-20190702054246-869f871628b6 h1:ZgQEtGgCBiWRM39fZuwSd1LwSqqSW0hOdXCYYDX0R3I=
 github.com/golang/groupcache v0.0.0-20190702054246-869f871628b6/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
@@ -79,6 +81,7 @@ github.com/google/go-cmp v0.2.0/go.mod h1:oXzfMopK8JAjlY9xF4vHSVASa0yLyX7SntLO5a
 github.com/google/go-cmp v0.3.0/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=
 github.com/google/go-cmp v0.3.1 h1:Xye71clBPdm5HgqGwUkwhbynsUJZhDbS20FvLhQ2izg=
 github.com/google/go-cmp v0.3.1/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=
+github.com/google/martian v2.1.0+incompatible h1:/CP5g8u/VJHijgedC/Legn3BAbAaWPgecwXBIDzw5no=
 github.com/google/martian v2.1.0+incompatible/go.mod h1:9I4somxYTbIHy5NJKHRl3wXiIaQGbYVAs8BPL6v8lEs=
 github.com/google/pprof v0.0.0-20181206194817-3ea8567a2e57/go.mod h1:zfwlbNMJ+OItoe0UupaVj+oy1omPYYDuagoSzA8v9mc=
 github.com/google/pprof v0.0.0-20190515194954-54271f7e092f/go.mod h1:zfwlbNMJ+OItoe0UupaVj+oy1omPYYDuagoSzA8v9mc=
@@ -126,7 +129,6 @@ github.com/hashicorp/terraform-config-inspect v0.0.0-20190821133035-82a99dc22ef4
 github.com/hashicorp/terraform-config-inspect v0.0.0-20190821133035-82a99dc22ef4/go.mod h1:JDmizlhaP5P0rYTTZB0reDMefAiJyfWPEtugV4in1oI=
 github.com/hashicorp/terraform-plugin-sdk v1.0.0 h1:3AjuuV1LJKs1NlG+heUgqWN6/QCSx2kDhyS6K7F0fTw=
 github.com/hashicorp/terraform-plugin-sdk v1.0.0/go.mod h1:NuwtLpEpPsFaKJPJNGtMcn9vlhe6Ofe+Y6NqXhJgV2M=
-github.com/hashicorp/terraform-plugin-sdk v1.4.0 h1:b1LluARpES0Gq78oF4a9of3eS0iXM5JTwlt604vGvBY=
 github.com/hashicorp/yamux v0.0.0-20180604194846-3520598351bb/go.mod h1:+NfK9FKeTrX5uv1uIXGdwYDTeHna2qgaIlx54MXqjAM=
 github.com/hashicorp/yamux v0.0.0-20181012175058-2f1d1f20f75d h1:kJCB4vdITiW1eC1vq2e6IsrXKrZit1bv/TDYFGMp4BQ=
 github.com/hashicorp/yamux v0.0.0-20181012175058-2f1d1f20f75d/go.mod h1:+NfK9FKeTrX5uv1uIXGdwYDTeHna2qgaIlx54MXqjAM=
@@ -141,10 +143,13 @@ github.com/keybase/go-crypto v0.0.0-20161004153544-93f5b35093ba/go.mod h1:ghbZsc
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
 github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/kr/logfmt v0.0.0-20140226030751-b84e30acd515/go.mod h1:+0opPa2QZZtGFBFZlji/RkVcI2GknAs/DXo4wKdlNEc=
+github.com/kr/pretty v0.1.0 h1:L/CwN0zerZDmRFUapSPitk6f+Q3+0za1rQkzVuMiMFI=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
+github.com/kr/text v0.1.0 h1:45sCR5RtlFHMR4UwH9sdQ5TC8v0qDQCHnXt+kaKSTVE=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
 github.com/kylelemons/godebug v0.0.0-20170820004349-d65d576e9348/go.mod h1:B69LEHPfb2qLo0BaaOLcbitczOKLWTsrBG9LczfCD4k=
+github.com/kylelemons/godebug v1.1.0 h1:RPNrshWIDI6G2gRW9EHilWtl7Z6Sb1BR0xunSBf0SNc=
 github.com/kylelemons/godebug v1.1.0/go.mod h1:9/0rRGxNHcop5bhtWyNeEfOS8JIWk580+fNqagV/RAw=
 github.com/mailru/easyjson v0.0.0-20180730094502-03f2033d19d5/go.mod h1:C1wdFJiN94OJF2b5HbByQZoLdCWB1Yqtg26g4irojpc=
 github.com/mailru/easyjson v0.0.0-20190626092158-b2ccc519800e h1:hB2xlXdHp/pmPZq0y3QnmWAArdw9PqbmotexnWx/FU8=
@@ -192,6 +197,7 @@ github.com/pierrec/lz4 v2.0.5+incompatible/go.mod h1:pdkljMzZIN41W+lC3N2tnIh5sFi
 github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.8.1 h1:iURUrRGxPUNPdy5/HRSm+Yj6okJ6UtLINN0Q9M4+h3I=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/posener/complete v1.1.1/go.mod h1:em0nMJCgc9GFtwrmVmEMR/ZL6WyhyjMBndrE9hABlRI=
 github.com/posener/complete v1.2.1 h1:LrvDIY//XNo65Lq84G/akBuMGlawHvGBABv8f/ZN6DI=
@@ -204,6 +210,7 @@ github.com/prometheus/common v0.2.0/go.mod h1:TNfzLD0ON7rHzMJeJkieUDPYmFC7Snx/y8
 github.com/prometheus/procfs v0.0.0-20181005140218-185b4288413d/go.mod h1:c3At6R/oaqEKCNdg8wHV1ftS6bRYblBhIjjI8uT2IGk=
 github.com/prometheus/procfs v0.0.0-20190117184657-bf6a532e95b1/go.mod h1:c3At6R/oaqEKCNdg8wHV1ftS6bRYblBhIjjI8uT2IGk=
 github.com/rcrowley/go-metrics v0.0.0-20181016184325-3113b8401b8a/go.mod h1:bCqnVzQkZxMG4s8nGwiZ5l3QUCyqpo9Y+/ZMZ9VjZe4=
+github.com/sergi/go-diff v1.0.0 h1:Kpca3qRNrduNnOQeazBd0ysaKrUJiIuISHxogkT9RPQ=
 github.com/sergi/go-diff v1.0.0/go.mod h1:0CfEIISq7TuYL3j771MWULgwwjU+GofnZX9QAmXWZgo=
 github.com/sirupsen/logrus v1.2.0/go.mod h1:LxeOpSwHxABJmUn/MG1IvRgCAasNZTLOkJPxbbu5VWo=
 github.com/smartystreets/go-aws-auth v0.0.0-20180515143844-0c1422d1fdb9/go.mod h1:SnhjPscd9TpLiy1LpzGSKh3bXCfxxXuqd9xmQJy3slM=
@@ -214,6 +221,7 @@ github.com/spf13/pflag v1.0.3/go.mod h1:DYY7MBk1bdzusC3SYhjObp+wFpr4gzcvqqNjLnIn
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
+github.com/stretchr/testify v1.3.0 h1:TivCn/peBQ7UY8ooIcPgZFpTNSz0Q2U6UrFlUfqbe0Q=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/ulikunitz/xz v0.5.5 h1:pFrO0lVpTBXLpYw+pnLj6TbvHuyjXMfjGeCwSqCVwok=
 github.com/ulikunitz/xz v0.5.5/go.mod h1:2bypXElzHzzJZwzH67Y6wb67pO62Rzfn7BSiF4ABRW8=
@@ -313,6 +321,7 @@ google.golang.org/api v0.9.0/go.mod h1:o4eAsZoiT+ibD93RtjEohWalFOjRDx6CVaqeizhEn
 google.golang.org/appengine v1.1.0/go.mod h1:EbEs0AVv82hx2wNQdGPgUI5lhzA/G0D9YwlJXL52JkM=
 google.golang.org/appengine v1.4.0/go.mod h1:xpcJRLb0r/rnEns0DIKYYv+WjYCduHsrkT7/EB5XEv4=
 google.golang.org/appengine v1.5.0/go.mod h1:xpcJRLb0r/rnEns0DIKYYv+WjYCduHsrkT7/EB5XEv4=
+google.golang.org/appengine v1.6.1 h1:QzqyMA1tlu6CgqCDUtU9V+ZKhLFT2dkJuANu5QaxI3I=
 google.golang.org/appengine v1.6.1/go.mod h1:i06prIuMbXzDqacNJfV5OdTW448YApPu5ww/cMBSeb0=
 google.golang.org/genproto v0.0.0-20180817151627-c66870c02cf8/go.mod h1:JiN7NxoALGmiZfu7CAH4rXhgtRTLTxftemlI0sWmxmc=
 google.golang.org/genproto v0.0.0-20190307195333-5fe7a883aa19/go.mod h1:VzzqZJRnGkLBvHegQrXjBqPurQTc5/KpmUdxsrq26oE=
@@ -331,6 +340,7 @@ google.golang.org/grpc v1.23.0 h1:AzbTB6ux+okLTzP8Ru1Xs41C303zdcfEht7MQnYJt5A=
 google.golang.org/grpc v1.23.0/go.mod h1:Y5yQAOtifL1yxbo5wqy6BxZv8vAUGQwXBOALyacEbxg=
 gopkg.in/alecthomas/kingpin.v2 v2.2.6/go.mod h1:FMv+mEhP44yOT+4EoQTLFTRgOQ1FBLkstjWtayDeSgw=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127 h1:qIbj1fsPNlZgppZ+VLlY7N33q108Sa+fhmuc+sWQYwY=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/cheggaaa/pb.v1 v1.0.27/go.mod h1:V/YB90LKu/1FcN3WVnfiiE5oMCibMjukxqG/qStrOgw=
 gopkg.in/fsnotify.v1 v1.4.7/go.mod h1:Tz8NjZHkW78fSQdbUxIjBTcgA1z1m8ZHf0WmKUhAMys=

--- a/test_aws_config
+++ b/test_aws_config
@@ -1,0 +1,3 @@
+[profile testing]
+aws_access_key_id = PROFILE_ACCESS_KEY
+aws_secret_access_key = PROFILE_SECRET_KEY 


### PR DESCRIPTION
So we can supply the provider with an AWS_PROFILE setting (we use this in our automated terraform pipelines - where different roles may be required for different resources.  So, being able to supply the profile in code is beneficial).
