### PR TITLE
Allow to specify AWS region for URL signing explicitly

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -65,11 +65,12 @@ The following arguments are supported:
 * `aws_secret_key` (Optional) - The secret key for use with AWS Elasticsearch Service domains. It can also be sourced from the `AWS_SECRET_ACCESS_KEY` environment variable.
 * `aws_token` (Optional) - The session token for use with AWS Elasticsearch Service domains. It can also be sourced from the `AWS_SESSION_TOKEN` environment variable.
 * `aws_profile` (Optional) - The AWS profile for use with AWS Elasticsearch Service domains
+* `aws_region` (Optional) - The AWS region for use in signing of AWS elasticsearch requests. Must be specified in order to use AWS URL signing with AWS ElasticSearch endpoint exposed on a custom DNS domain.
 * `cacert_file` (Optional) - a custom CA certificate when communicating over SSL. You can specify either a path to the file or the contents of the certificate.
-* `insecure` (Optional) - Disable SSL verification of API calls (defaults to false)
+* `insecure` (Optional) - Disable SSL verification of API calls (defaults to `false`)
 * `client_cert_path` (Optional) - A X509 certificate to connect to elasticsearch. Defaults to `ES_CLIENT_CERTIFICATE_PATH` from the environment
 * `client_key_path` (Optional) - A X509 key to connect to elasticsearch. Defaults to `ES_CLIENT_KEY_PATH`
-* `sign_aws_requests` (Optional) - Enable signing of AWS elasticsearch requests (defauls to true).
+* `sign_aws_requests` (Optional) - Enable signing of AWS elasticsearch requests (defauls to `true`). The `url` must refer to AWS ES domain (`*.<region>.es.amazonaws.com`), or `aws_region` must be specified explicitly.
 * `elasticsearch_version` (Optional) - ElasticSearch Version, if set, skips the version detection at provider start.
 
 ### AWS authentication

--- a/es/provider.go
+++ b/es/provider.go
@@ -86,6 +86,13 @@ func Provider() terraform.ResourceProvider {
 				Description: "The AWS profile for use with AWS Elasticsearch Service domains",
 			},
 
+			"aws_region": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Default:     "",
+				Description: "The AWS region for use in signing of AWS elasticsearch requests. Must be specified in order to use AWS URL signing with AWS ElasticSearch endpoint exposed on a custom DNS domain.",
+			},
+
 			"cacert_file": {
 				Type:        schema.TypeString,
 				Optional:    true,
@@ -117,7 +124,7 @@ func Provider() terraform.ResourceProvider {
 				Type:        schema.TypeBool,
 				Optional:    true,
 				Default:     true,
-				Description: "Enable signing of AWS elasticsearch requests",
+				Description: "Enable signing of AWS elasticsearch requests. The `url` must refer to AWS ES domain (`*.<region>.es.amazonaws.com`), or `aws_region` must be specified explicitly.",
 			},
 			"elasticsearch_version": {
 				Type:        schema.TypeString,
@@ -193,6 +200,9 @@ func providerConfigure(d *schema.ResourceData) (interface{}, error) {
 	if m := awsUrlRegexp.FindStringSubmatch(parsedUrl.Hostname()); m != nil && signAWSRequests {
 		log.Printf("[INFO] Using AWS: %+v", m[1])
 		opts = append(opts, elastic7.SetHttpClient(awsHttpClient(m[1], d)), elastic7.SetSniff(false))
+	} else if awsRegion := d.Get("aws_region").(string); awsRegion != "" && signAWSRequests {
+		log.Printf("[INFO] Using AWS: %+v", awsRegion)
+		opts = append(opts, elastic7.SetHttpClient(awsHttpClient(awsRegion, d)), elastic7.SetSniff(false))
 	} else if insecure || cacertFile != "" {
 		opts = append(opts, elastic7.SetHttpClient(tlsHttpClient(d)), elastic7.SetSniff(false))
 	}
@@ -233,6 +243,9 @@ func providerConfigure(d *schema.ResourceData) (interface{}, error) {
 		if m := awsUrlRegexp.FindStringSubmatch(parsedUrl.Hostname()); m != nil && signAWSRequests {
 			log.Printf("[INFO] Using AWS: %+v", m[1])
 			opts = append(opts, elastic6.SetHttpClient(awsHttpClient(m[1], d)), elastic6.SetSniff(false))
+		} else if awsRegion := d.Get("aws_region").(string); awsRegion != "" && signAWSRequests {
+			log.Printf("[INFO] Using AWS: %+v", awsRegion)
+			opts = append(opts, elastic6.SetHttpClient(awsHttpClient(awsRegion, d)), elastic6.SetSniff(false))
 		} else if insecure || cacertFile != "" {
 			opts = append(opts, elastic6.SetHttpClient(tlsHttpClient(d)), elastic6.SetSniff(false))
 		}
@@ -259,6 +272,9 @@ func providerConfigure(d *schema.ResourceData) (interface{}, error) {
 
 		if m := awsUrlRegexp.FindStringSubmatch(parsedUrl.Hostname()); m != nil && signAWSRequests {
 			opts = append(opts, elastic5.SetHttpClient(awsHttpClient(m[1], d)), elastic5.SetSniff(false))
+		} else if awsRegion := d.Get("aws_region").(string); awsRegion != "" && signAWSRequests {
+			log.Printf("[INFO] Using AWS: %+v", awsRegion)
+			opts = append(opts, elastic5.SetHttpClient(awsHttpClient(awsRegion, d)), elastic5.SetSniff(false))
 		} else if insecure || cacertFile != "" {
 			opts = append(opts, elastic5.SetHttpClient(tlsHttpClient(d)), elastic5.SetSniff(false))
 		}


### PR DESCRIPTION
### Why do we need it? 

We configure AWS ElasticSearch to expose the endpoints internally on VPC, with an additional reverse proxy to expose ES and Kibana publicly via a custom domain. Terraform also connects to that external endpoint for configuring the ES domain, and Terraform authenticates via AWS IAM role, instead of using the admin username/password. So we need to use AWS URL signing, and with the current version of the provider it is only possible for URLs in `es.amazonws.com` subdomain, because the provider parses the domain name to extract AWS region.

### What is being proposed?

Allow to specify AWS region explicitly and use it to configure URL signing for custom domains.