### PR TITLE
Allow omitting tenant permissions

### DIFF
--- a/es/resource_elasticsearch_opendistro_role.go
+++ b/es/resource_elasticsearch_opendistro_role.go
@@ -299,9 +299,9 @@ type RoleResponse struct {
 
 type RoleBody struct {
 	Description        string              `json:"description"`
-	ClusterPermissions []string            `json:"cluster_permissions"`
-	IndexPermissions   []IndexPermissions  `json:"index_permissions"`
-	TenantPermissions  []TenantPermissions `json:"tenant_permissions"`
+	ClusterPermissions []string            `json:"cluster_permissions,omitempty"`
+	IndexPermissions   []IndexPermissions  `json:"index_permissions,omitempty"`
+	TenantPermissions  []TenantPermissions `json:"tenant_permissions,omitempty"`
 }
 
 type IndexPermissions struct {

--- a/es/resource_elasticsearch_opendistro_role_test.go
+++ b/es/resource_elasticsearch_opendistro_role_test.go
@@ -86,6 +86,17 @@ func TestAccElasticsearchOpenDistroRole(t *testing.T) {
 					),
 				),
 			},
+			{
+				Config: testAccOpenDistroRoleResourceWithoutTenantPermissions(randomName),
+				Check: resource.ComposeTestCheckFunc(
+					testCheckElasticSearchOpenDistroRoleExists("elasticsearch_opendistro_role.test"),
+					resource.TestCheckResourceAttr(
+						"elasticsearch_opendistro_role.test",
+						"tenant_permissions.#",
+						"0",
+					),
+				),
+			},
 		},
 	})
 }
@@ -213,6 +224,36 @@ func testAccOpenDistroRoleResourceUpdated(resourceName string) string {
 
 			allowed_actions = [
 				"kibana_all_write",
+			]
+		}
+
+		cluster_permissions = ["*"]
+	}
+	`, resourceName)
+}
+
+func testAccOpenDistroRoleResourceWithoutTenantPermissions(resourceName string) string {
+	return fmt.Sprintf(`
+	resource "elasticsearch_opendistro_role" "test" {
+		role_name = "%s"
+		description = "test"
+		index_permissions {
+			index_patterns = [
+				"test*",
+			]
+
+			allowed_actions = [
+				"read",
+			]
+		}
+
+		index_permissions {
+			index_patterns = [
+				"?kibana",
+			]
+
+			allowed_actions = [
+				"indices_all",
 			]
 		}
 


### PR DESCRIPTION
Tenant permissions for the role are optional, but not specifying them in the resource leads to the following API error:

```
Error: error creating role mapping: elastic: Error 400 (Bad Request): []
```

This simple change fixes the problem by not sending the empty permissions list in the JSON document.