### PR TITLE
Fix opendistro ism policy version conflict

### DIFF
--- a/es/resource_elasticsearch_opendistro_ism_policy.go
+++ b/es/resource_elasticsearch_opendistro_ism_policy.go
@@ -183,7 +183,7 @@ func resourceElasticsearchPutOpenDistroISMPolicy(d *schema.ResourceData, m inter
 	primTerm := d.Get("primary_term").(int)
 	params := url.Values{}
 
-	if seq > 0 && primTerm > 0 {
+	if seq >= 0 && primTerm > 0 {
 		params.Set("if_seq_no", strconv.Itoa(seq))
 		params.Set("if_primary_term", strconv.Itoa(primTerm))
 	}


### PR DESCRIPTION
Hey @phillbaker.

First, thanks for this really great `terraform` provider!
Currently, we are facing an issue when updating the first created Open Distro ISM Policy.

The **issue** is, that the first ISM Policy has a `seq_no = 0` and as a result the `seq_no` and `primary_term` parameters are not set to update an existing policy:

```
$ terraform plan               
Refreshing Terraform state in-memory prior to plan...
The refreshed state will be used to calculate this plan, but will not be
persisted to local or remote state storage.

elasticsearch_opendistro_ism_policy.test: Refreshing state... [id=test]

------------------------------------------------------------------------

An execution plan has been generated and is shown below.
Resource actions are indicated with the following symbols:
  ~ update in-place

Terraform will perform the following actions:

  # elasticsearch_opendistro_ism_policy.test will be updated in-place
  ~ resource "elasticsearch_opendistro_ism_policy" "test" {
      ~ body         = jsonencode(
          ~ {
            ...
            }
        )
        id           = "test"
        policy_id    = "test"
        primary_term = 1
        seq_no       = 0
    }

Plan: 0 to add, 1 to change, 0 to destroy.
```

---

Here are the steps to reproduce:

1. Create the following `main.tf` file:
```
terraform {
  required_providers {
    elasticsearch = {
      source  = "phillbaker/elasticsearch"
      version = "~> 1.4.4"
    }
  }
}

provider elasticsearch {
  url      = "http://localhost:9220"
  username = "admin"
  password = "admin"
}

resource elasticsearch_opendistro_ism_policy "test" {
  policy_id = "test"
  body      = <<EOF
{
  "policy": {
    "description": "Demonstrate a hot-delete workflow.",
    "default_state": "hot",
    "schema_version": 1,
    "states": [
      {
        "name": "hot",
        "actions": [],
        "transitions": [
          {
            "state_name": "delete",
            "conditions": {
              "min_index_age": "7d"
            }
          }
        ]
      },
      {
        "name": "delete",
        "actions": [
          {
            "delete": {}
          }
        ],
        "transitions": []
      }
    ]
  }
}
  EOF
}
```

2. Start a new Elasticsearch Opendistro Contrainer:
```
$ export ES_OPENDISTRO_IMAGE=amazon/opendistro-for-elasticsearch
$ docker-compose up -d opendistro
Creating network "terraform-provider-elasticsearch_default" with the default driver
Creating terraform-provider-elasticsearch_opendistro_1 ... done
```

3. Create an ISM Policy:
```
$ terraform init > /dev/null && terraform apply -auto-approve
elasticsearch_opendistro_ism_policy.test: Creating...
elasticsearch_opendistro_ism_policy.test: Creation complete after 1s [id=test]

Apply complete! Resources: 1 added, 0 changed, 0 destroyed.
```

4. Change the condition `"min_index_age": "7d"` to `"min_index_age": "14d"` in the `main.tf` file.

5. After `terraform apply`, then you will get this error message:
```
$ terraform apply -auto-approve
elasticsearch_opendistro_ism_policy.test: Refreshing state... [id=test]
elasticsearch_opendistro_ism_policy.test: Modifying... [id=test]

Error: error putting policy: /_opendistro/_ism/policies/test : {
  "policy": {
    ...
  }
}
 : elastic: Error 409 (Conflict): [test]: version conflict, document already exists (current version [1]) [type=version_conflict_engine_exception]

  on main.tf line 16, in resource "elasticsearch_opendistro_ism_policy" "test":
  16: resource elasticsearch_opendistro_ism_policy "test" {
```