### PR TITLE
Follow rollover alias when index is managed by ILM or ISM

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 ## Unreleased
 ### Changed
 - Deprecated elasticsearch_index_lifecycle_policy in favor of elasticsearch_xpack_index_lifecycle_policy.
+- Don't recreate indices which are managed by ILM or ISM for the resource `elasticsearch_index` (#75).
 
 ### Added
 - Validation for kibana objects to prevent provider crashes.


### PR DESCRIPTION
Hi @phillbaker.

Today, I want to fix the issue #75. The idea in this PR was already discussed in #55.

1. When creating an index, inspect the response for an ILM/ISM lifecycle policy.
2. If the ILM/ISM lifecycle policy contains the setting `rollover_alias`, set this field in the Terraform state.
3. On the next `terraform` run: If the `rollover_alias` is present then use this value to get the current `is_write_index`.

---

For example, you can use the following steps to reproduce:

1. Create the following `main.tf` file: 

```
provider "elasticsearch" {
  url = "http://localhost:9200"
}

resource "elasticsearch_index_lifecycle_policy" "test" {
  name = "test"
  body = <<EOF
{
  "policy": {
    "phases": {
      "hot": {
        "min_age": "0ms",
        "actions": {
          "rollover": {
            "max_size": "50gb"
          }
        }
      }
    }
  }
}
EOF
}

resource "elasticsearch_index_template" "test" {
  name = "test"
  body = <<EOF
{
  "index_patterns": [
    "test-*"
  ],
  "settings": {
    "index": {
      "lifecycle": {
        "name": "${elasticsearch_index_lifecycle_policy.test.name}",
        "rollover_alias": "test"
      }
    }
  }
}
EOF
}

resource "elasticsearch_index" "test" {
  name               = "test-000001"
  number_of_shards   = 1
  number_of_replicas = 1
  aliases = jsonencode({
    "test" = {
      "is_write_index" = true
    }
  })

  depends_on = [elasticsearch_index_template.test]
}
```

2. Start a new Elasticsearch Contrainer:

```
$ export ES_OSS_IMAGE=elasticsearch:7.9.2
$ docker-compose up -d elasticsearch
Creating network "terraform-provider-elasticsearch_default" with the default driver
Creating terraform-provider-elasticsearch_elasticsearch_1 ... done
```

3. Create the example Index Lifecycle Policy, Index Template and Index:

```
$ terraform apply -auto-approve  
elasticsearch_index_lifecycle_policy.test: Creating...
elasticsearch_index_lifecycle_policy.test: Creation complete after 0s [id=test]
elasticsearch_index_template.test: Creating...
elasticsearch_index_template.test: Creation complete after 0s [id=test]
elasticsearch_index.test: Creating...
elasticsearch_index.test: Creation complete after 0s [id=test-000001]

Apply complete! Resources: 3 added, 0 changed, 0 destroyed.
```

4. Manually rollover the example index:

```
$ curl -X POST http://localhost:9200/test/_rollover 
{"acknowledged":true,"shards_acknowledged":true,"old_index":"test-000001","new_index":"test-000002","rolled_over":true,"dry_run":false,"conditions":{}}
```

5. Delete the initial created index:

```
$ curl -X DELETE http://localhost:9200/test-000001
{"acknowledged":true}
```

6. Now all changes will be made to the index `test-000002`.