### PR TITLE
Add support for AWS Assume Role

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 ### Added
 - Validation for kibana objects to prevent provider crashes.
 - Add XPack license resource, compatible with ES version >= 6.2.
+- Add `assume_role` support for authenticating to AWS
 
 ## [1.4.4] - 2020-09-23
 ### Added

--- a/docs/index.md
+++ b/docs/index.md
@@ -61,6 +61,7 @@ The following arguments are supported:
 * `healthcheck` (Optional) - Set the client healthcheck option for the elastic client. Healthchecking is designed for direct access to the cluster. Defaults to `ELASTICSEARCH_HEALTH` from the environment, or true.
 * `username` (Optional) - Username to use to connect to elasticsearch using basic auth. Defaults to `ELASTICSEARCH_USERNAME` from the environment
 * `password` (Optional) - Password to use to connect to elasticsearch using basic auth. Defaults to `ELASTICSEARCH_PASSWORD` from the environment
+* `aws_assume_role_arn` (Optional) - ARN of role to assume when using AWS Elasticsearch Service domains.
 * `aws_access_key` (Optional) - The access key for use with AWS Elasticsearch Service domains. It can also be sourced from the `AWS_ACCESS_KEY_ID` environment variable.
 * `aws_secret_key` (Optional) - The secret key for use with AWS Elasticsearch Service domains. It can also be sourced from the `AWS_SECRET_ACCESS_KEY` environment variable.
 * `aws_token` (Optional) - The session token for use with AWS Elasticsearch Service domains. It can also be sourced from the `AWS_SESSION_TOKEN` environment variable.
@@ -78,6 +79,7 @@ The following arguments are supported:
 The Elasticsearch provider is flexible in the means of providing credentials for authentication with AWS Elasticsearch domains. The following methods are supported, in this order, and explained below:
 
 - Static credentials
+- Assume role configuration
 - Environment variables
 - Shared credentials file
 
@@ -93,6 +95,19 @@ provider "elasticsearch" {
     aws_access_key = "anaccesskey"
     aws_secret_key = "asecretkey"
     aws_token = "" # if necessary
+}
+```
+
+#### Assume role configuration
+
+You can instruct the provider to assume a role in AWS before interacting with Elasticsearch by setting the `aws_assume_role_arn` variable.
+
+Example usage:
+
+```tf
+provider "elasticsearch" {
+    url = "https://search-foo-bar-pqrhr4w3u4dzervg41frow4mmy.us-east-1.es.amazonaws.com"
+    aws_assume_role_arn = "arn:aws:iam::012345678901:role/rolename`
 }
 ```
 

--- a/es/provider_test.go
+++ b/es/provider_test.go
@@ -176,6 +176,25 @@ func TestAWSCredsEnvNamedProfile(t *testing.T) {
 	os.Unsetenv("AWS_SDK_LOAD_CONFIG")
 }
 
+// Given:
+// 1. An AWS role ARN is specified
+// 2. No additional AWS configuration is provided to the provider
+//
+// This tests that: we can safely generate a session. Note we cannot get the credentials, because that requires connecting to AWS
+func TestAWSCredsAssumeRole(t *testing.T) {
+	testRegion := "us-east-1"
+
+	testConfig := map[string]interface{}{
+		"aws_assume_role_arn": "test_arn",
+	}
+
+	testConfigData := schema.TestResourceDataRaw(t, Provider().(*schema.Provider).Schema, testConfig)
+	s := awsSession(testRegion, testConfigData)
+	if s == nil {
+		t.Fatalf("awsSession returned nil")
+	}
+}
+
 func getCreds(t *testing.T, region string, config map[string]interface{}) credentials.Value {
 	testConfigData := schema.TestResourceDataRaw(t, Provider().(*schema.Provider).Schema, config)
 	s := awsSession(region, testConfigData)


### PR DESCRIPTION
Add support for authenticating to AWS using an assume role ARN. This is
a very basic implementation with limited configuration options, but is
sufficient for simple use cases

Fixes #98 

@phillbaker I'm not sure how you'd want to approach automated testing with this (I've included a limited example), but I can confirm from manual tests that this works as expected.