### PR TITLE
Add Document Level Security support for Opendistro role

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,16 +1,17 @@
 # Changelog
 ## Unreleased
 ### Changed
--
+- [open distro role] Rename fls in favor of field_level_security
 
 ### Added
--
+- [open distro role] Add support for OpenDistro document-level-security in role.
 
 ## [1.5.1] - 2020-12-23
 ### Changed
 - Gracefully handle the case where `elasticsearch_index_template` objects exist in the terraform state but not in the ES domain (e.g. because they were manually deleted.)
 - Create index `aliases` and `mappings` even if no settings are set.
 - Bump aws client to v1.35.33.
+<<<<<<< HEAD
 - Allow provider variable interpolation by deferring client instantiation, `providerConfigure` only returns a configuration struct.
 - Fix XPack license resource having perpetual diff if using basic license.
 - [aws auth] Pass profile on assume role.

--- a/docs/resources/opendistro_role.md
+++ b/docs/resources/opendistro_role.md
@@ -33,6 +33,23 @@ resource "elasticsearch_opendistro_role" "writer" {
 }
 ```
 
+To set document level permissions:
+
+```hcl
+resource "elasticsearch_opendistro_role" "writer" {
+  role_name   = "foo_writer"
+
+  cluster_permissions = ["*"]
+
+  index_permissions {
+    index_patterns  = ["pub*"]
+    allowed_actions = ["read"]
+    document_level_security = "{\"term\": { \"readable_by\": \"$${user.name}\"}}"
+  }
+}
+```
+
+
 ## Argument Reference
 
 The following arguments are supported:
@@ -52,17 +69,19 @@ The `index_permissions` object supports the following:
 
 * `index_patterns` -
     (Optional) A list of glob patterns for the index names.
-* `fls` -
-    (Optional) A list of selectors for [field-level security][2].
+* `document_level_security` -
+    (Optional) A selector for [document-level security][2] (json formatted using jsonencode).
+* `field_level_security` -
+    (Optional) A list of selectors for [field-level security][3].
 * `masked_fields` -
-    (Optional) A list of [masked fields][3].
+    (Optional) A list of [masked fields][4].
 * `allowed_actions` -
     (Optional) A list of allowed actions.
 
 The `tenant_permissions` object supports the following:
 
 * `tenant_patterns` -
-    (Optional) A list of glob patterns for the [tenant][4] names.
+    (Optional) A list of glob patterns for the [tenant][5] names.
 * `allowed_actions` -
     (Optional) A list of allowed actions.
 
@@ -83,6 +102,7 @@ $ terraform import elasticsearch_opendistro_role.writer logs_writer
 
 <!-- External links -->
 [1]: https://opendistro.github.io/for-elasticsearch-docs/docs/security/access-control/
-[2]: https://opendistro.github.io/for-elasticsearch-docs/docs/security/access-control/field-level-security/
-[3]: https://opendistro.github.io/for-elasticsearch-docs/docs/security/access-control/field-masking/
-[4]: https://opendistro.github.io/for-elasticsearch-docs/docs/security/access-control/multi-tenancy/
+[1]: https://opendistro.github.io/for-elasticsearch-docs/docs/security/access-control/document-level-security/
+[3]: https://opendistro.github.io/for-elasticsearch-docs/docs/security/access-control/field-level-security/
+[4]: https://opendistro.github.io/for-elasticsearch-docs/docs/security/access-control/field-masking/
+[5]: https://opendistro.github.io/for-elasticsearch-docs/docs/security/access-control/multi-tenancy/

--- a/docs/resources/opendistro_role.md
+++ b/docs/resources/opendistro_role.md
@@ -71,6 +71,8 @@ The `index_permissions` object supports the following:
     (Optional) A list of glob patterns for the index names.
 * `document_level_security` -
     (Optional) A selector for [document-level security][2] (json formatted using jsonencode).
+* `fls` -
+    (Optional) Deprecated, use `field_level_security` instead. A list of selectors for [field-level security][3].
 * `field_level_security` -
     (Optional) A list of selectors for [field-level security][3].
 * `masked_fields` -

--- a/es/resource_elasticsearch_opendistro_role.go
+++ b/es/resource_elasticsearch_opendistro_role.go
@@ -47,6 +47,15 @@ func resourceElasticsearchOpenDistroRole() *schema.Resource {
 							Type:     schema.TypeString,
 							Optional: true,
 						},
+						"fls": {
+							Type:     schema.TypeSet,
+							Optional: true,
+							Elem: &schema.Schema{
+								Type: schema.TypeString,
+							},
+							Set:        schema.HashString,
+							Deprecated: "`fls` has been deprecated, please use `field_level_security`",
+						},
 						"field_level_security": {
 							Type:     schema.TypeSet,
 							Optional: true,
@@ -143,7 +152,7 @@ func resourceElasticsearchOpenDistroRoleRead(d *schema.ResourceData, m interface
 	if err := d.Set("cluster_permissions", res.ClusterPermissions); err != nil {
 		return fmt.Errorf("error setting cluster_permissions: %s", err)
 	}
-	if err := d.Set("index_permissions", flattenIndexPermissions(res.IndexPermissions)); err != nil {
+	if err := d.Set("index_permissions", flattenIndexPermissions(res.IndexPermissions, d)); err != nil {
 		return fmt.Errorf("error setting index_permissions: %s", err)
 	}
 	if err := d.Set("description", res.Description); err != nil {

--- a/es/resource_elasticsearch_opendistro_role.go
+++ b/es/resource_elasticsearch_opendistro_role.go
@@ -43,7 +43,11 @@ func resourceElasticsearchOpenDistroRole() *schema.Resource {
 							},
 							Set: schema.HashString,
 						},
-						"fls": {
+						"document_level_security": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+						"field_level_security": {
 							Type:     schema.TypeSet,
 							Optional: true,
 							Elem: &schema.Schema{
@@ -235,10 +239,11 @@ func resourceElasticsearchPutOpenDistroRole(d *schema.ResourceData, m interface{
 	var indexPermissionsBody []IndexPermissions
 	for _, idx := range indexPermissions {
 		putIdx := IndexPermissions{
-			IndexPatterns:  idx.IndexPatterns,
-			Fls:            idx.Fls,
-			MaskedFields:   idx.MaskedFields,
-			AllowedActions: idx.AllowedActions,
+			IndexPatterns:         idx.IndexPatterns,
+			DocumentLevelSecurity: idx.DocumentLevelSecurity,
+			FieldLevelSecurity:    idx.FieldLevelSecurity,
+			MaskedFields:          idx.MaskedFields,
+			AllowedActions:        idx.AllowedActions,
 		}
 		indexPermissionsBody = append(indexPermissionsBody, putIdx)
 	}
@@ -317,10 +322,11 @@ type RoleBody struct {
 }
 
 type IndexPermissions struct {
-	IndexPatterns  []string `json:"index_patterns"`
-	Fls            []string `json:"fls"`
-	MaskedFields   []string `json:"masked_fields"`
-	AllowedActions []string `json:"allowed_actions"`
+	IndexPatterns         []string `json:"index_patterns"`
+	DocumentLevelSecurity string   `json:"dls"`
+	FieldLevelSecurity    []string `json:"fls"`
+	MaskedFields          []string `json:"masked_fields"`
+	AllowedActions        []string `json:"allowed_actions"`
 }
 
 type TenantPermissions struct {

--- a/es/util.go
+++ b/es/util.go
@@ -338,8 +338,11 @@ func flattenIndexPermissions(permissions []IndexPermissions) []map[string]interf
 		if len(permission.IndexPatterns) > 0 {
 			p["index_patterns"] = flattenStringSet(permission.IndexPatterns)
 		}
-		if len(permission.Fls) > 0 {
-			p["fls"] = flattenStringSet(permission.Fls)
+		if len(permission.DocumentLevelSecurity) > 0 {
+			p["document_level_security"] = permission.DocumentLevelSecurity
+		}
+		if len(permission.FieldLevelSecurity) > 0 {
+			p["fields_level_security"] = flattenStringSet(permission.FieldLevelSecurity)
 		}
 		if len(permission.MaskedFields) > 0 {
 			p["masked_fields"] = flattenStringSet(permission.MaskedFields)
@@ -362,10 +365,11 @@ func expandIndexPermissionsSet(resourcesArray []interface{}) ([]IndexPermissions
 			return vperm, fmt.Errorf("Error asserting data as type []byte : %v", item)
 		}
 		obj := IndexPermissions{
-			IndexPatterns:  expandStringList(data["index_patterns"].(*schema.Set).List()),
-			Fls:            expandStringList(data["fls"].(*schema.Set).List()),
-			MaskedFields:   expandStringList(data["masked_fields"].(*schema.Set).List()),
-			AllowedActions: expandStringList(data["allowed_actions"].(*schema.Set).List()),
+			IndexPatterns:         expandStringList(data["index_patterns"].(*schema.Set).List()),
+			DocumentLevelSecurity: data["document_level_security"].(string),
+			FieldLevelSecurity:    expandStringList(data["field_level_security"].(*schema.Set).List()),
+			MaskedFields:          expandStringList(data["masked_fields"].(*schema.Set).List()),
+			AllowedActions:        expandStringList(data["allowed_actions"].(*schema.Set).List()),
 		}
 		vperm = append(vperm, obj)
 	}
@@ -424,7 +428,12 @@ func indexPermissionsHash(v interface{}) int {
 			buf.WriteString(fmt.Sprintf("%s-", v))
 		}
 	}
-	if v, ok := m["fls"]; ok {
+
+	if v, ok := m["document_level_security"]; ok {
+		buf.WriteString(fmt.Sprintf("%s-", v.(string)))
+	}
+
+	if v, ok := m["field_level_security"]; ok {
 		vs := v.(*schema.Set).List()
 		s := make([]string, len(vs))
 		for i, raw := range vs {


### PR DESCRIPTION
In the same way as Field Level Security, I propose to add support for Document Level Security in Opendistro Role.
See documentation here https://opendistro.github.io/for-elasticsearch-docs/docs/security/access-control/document-level-security/