### PR TITLE
Create index aliases and mappings even if no settings are set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 ## Unreleased
 ### Changed
--
+- Create index `aliases` and `mappings` even if no settings are set.
 
 ### Added
 -

--- a/es/resource_elasticsearch_index.go
+++ b/es/resource_elasticsearch_index.go
@@ -134,26 +134,26 @@ func resourceElasticsearchIndexCreate(d *schema.ResourceData, meta interface{}) 
 	)
 	if len(settings) > 0 {
 		body["settings"] = settings
+	}
 
-		if aliasJson, ok := d.GetOk("aliases"); ok {
-			var aliases map[string]interface{}
-			bytes := []byte(aliasJson.(string))
-			err = json.Unmarshal(bytes, &aliases)
-			if err != nil {
-				return fmt.Errorf("fail to unmarshal: %v", err)
-			}
-			body["aliases"] = aliases
+	if aliasJSON, ok := d.GetOk("aliases"); ok {
+		var aliases map[string]interface{}
+		bytes := []byte(aliasJSON.(string))
+		err = json.Unmarshal(bytes, &aliases)
+		if err != nil {
+			return fmt.Errorf("fail to unmarshal: %v", err)
 		}
+		body["aliases"] = aliases
+	}
 
-		if mappingsJson, ok := d.GetOk("mappings"); ok {
-			var mappings map[string]interface{}
-			bytes := []byte(mappingsJson.(string))
-			err = json.Unmarshal(bytes, &mappings)
-			if err != nil {
-				return fmt.Errorf("fail to unmarshal: %v", err)
-			}
-			body["mappings"] = mappings
+	if mappingsJSON, ok := d.GetOk("mappings"); ok {
+		var mappings map[string]interface{}
+		bytes := []byte(mappingsJSON.(string))
+		err = json.Unmarshal(bytes, &mappings)
+		if err != nil {
+			return fmt.Errorf("fail to unmarshal: %v", err)
 		}
+		body["mappings"] = mappings
 	}
 
 	// if date math is used, we need to pass the resolved name along to the read


### PR DESCRIPTION
Hi, me again.

Currently, we are facing an issue when creating indices with empty settings.
These are actually not necessary because the index template contains already the desired configuration.

But the current implementation results in an unexpected behavior. The index is created without the alias:

```
resource "elasticsearch_index" "test" {
  name               = "test-000001"
  number_of_shards   = ""
  number_of_replicas = ""
  refresh_interval   = ""

  aliases = jsonencode({
    "test" = {
      "is_write_index" = true
    }
  })
}
```

```
GET /_alias/test
{
  "error" : "alias [test] missing",
  "status" : 404
}
```