### PR TITLE
Handle the case where an index template that exists in the state is missing from the ES domain (e.g. has been manually deleted.)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,8 @@ sudo: required # required for docker
 language: go
 go:
   - '1.14'
-  - master
+git:
+  depth: false # we depend on full git history for linters
 cache:
   directories:
     - $HOME/gopath/pkg/mod
@@ -34,8 +35,8 @@ install:
   - curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | bash -s -- -b $GOPATH/bin v1.27.0
 before_script:
   - export GO111MODULE=on
-  # linters and checks
-  - golangci-lint run --new-from-rev=bf51aaa --timeout=10m
+  # Linters and checks
+  - golangci-lint run --new-from-rev=bf51aaa --verbose --timeout=10m
   - ./script/test-mod-tidy
   # ensure that ES has come up and is available
   - wget -q --waitretry=1 --retry-connrefused --tries=60 --timeout 60 -O - $ELASTICSEARCH_URL

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 ## Unreleased
 ### Changed
+- Gracefully handle the case where `elasticsearch_index_template` objects exist in the terraform state but not in the ES domain (e.g. because they were manually deleted.)
 - Create index `aliases` and `mappings` even if no settings are set.
 - Bump aws client to v1.35.33.
 

--- a/es/resource_elasticsearch_index_template.go
+++ b/es/resource_elasticsearch_index_template.go
@@ -3,6 +3,7 @@ package es
 import (
 	"context"
 	"encoding/json"
+	"log"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
@@ -60,6 +61,12 @@ func resourceElasticsearchIndexTemplateRead(d *schema.ResourceData, meta interfa
 		result, err = elastic5IndexGetTemplate(elastic5Client, id)
 	}
 	if err != nil {
+		if elastic7.IsNotFound(err) || elastic6.IsNotFound(err) || elastic5.IsNotFound(err) {
+			log.Printf("[WARN] Index template (%s) not found, removing from state", id)
+			d.SetId("")
+			return nil
+		}
+
 		return err
 	}
 


### PR DESCRIPTION
Thanks for authoring this provider; I love managing ES in code with `terraform` instead of in my brain with clicks and keystrokes!

I ran into an issue when I was replacing an ES domain, where if an index template was stored in the TF state but didn't exist within ES, the `terraform plan` would error with a 404 error. This PR fixed it for me locally.

I _thought about_ adding tests, but I'm a n00b to both `go` and `travis`, so I didn't.