### PR TITLE
Moving client creation to resource to allow for provider interpolation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 - Gracefully handle the case where `elasticsearch_index_template` objects exist in the terraform state but not in the ES domain (e.g. because they were manually deleted.)
 - Create index `aliases` and `mappings` even if no settings are set.
 - Bump aws client to v1.35.33.
+- Allow provider variable interpolation by deferring client instanation, `providerConfigure` only returns a configuration struct.
 
 ### Added
 -

--- a/README.md
+++ b/README.md
@@ -284,4 +284,4 @@ See LICENSE.
 2. Create your feature branch (`git checkout -b my-new-feature`)
 3. Commit your changes (`git commit -am 'Add some feature'`)
 4. Push to the branch (`git push origin my-new-feature`)
-5. Create a new Pull Request
+5. Create a new Pull Request 

--- a/README.md
+++ b/README.md
@@ -284,4 +284,4 @@ See LICENSE.
 2. Create your feature branch (`git checkout -b my-new-feature`)
 3. Commit your changes (`git commit -am 'Add some feature'`)
 4. Push to the branch (`git push origin my-new-feature`)
-5. Create a new Pull Request 
+5. Create a new Pull Request

--- a/es/data_source_elasticsearch_host.go
+++ b/es/data_source_elasticsearch_host.go
@@ -32,9 +32,12 @@ func dataSourceElasticsearchHostRead(d *schema.ResourceData, m interface{}) erro
 	// The upstream elastic client does not export the property for the urls
 	// it's using. Presumably the URLS would be available where the client is
 	// intantiated, but in terraform, that's not always practicable.
-
 	var err error
-	switch client := m.(type) {
+	esClient, err := getClient(m.(*ProviderConf))
+	if err != nil {
+		return err
+	}
+	switch client := esClient.(type) {
 	case *elastic7.Client:
 		urls := reflect.ValueOf(client).Elem().FieldByName("urls")
 		if urls.Len() > 0 {
@@ -46,7 +49,7 @@ func dataSourceElasticsearchHostRead(d *schema.ResourceData, m interface{}) erro
 			d.SetId(urls.Index(0).String())
 		}
 	default:
-		client = m.(*elastic5.Client)
+		client = esClient.(*elastic5.Client)
 
 		urls := reflect.ValueOf(client).Elem().FieldByName("urls")
 		if urls.Len() > 0 {

--- a/es/data_source_elasticsearch_opendistro_destination.go
+++ b/es/data_source_elasticsearch_opendistro_destination.go
@@ -50,7 +50,11 @@ func dataSourceElasticsearchOpenDistroDestinationRead(d *schema.ResourceData, m 
 	var id string
 	var body *json.RawMessage
 	var err error
-	switch client := m.(type) {
+	esClient, err := getClient(m.(*ProviderConf))
+	if err != nil {
+		return err
+	}
+	switch client := esClient.(type) {
 	case *elastic7.Client:
 		id, body, err = elastic7Search(client, DESTINATION_INDEX, destinationName)
 	case *elastic6.Client:

--- a/es/data_source_elasticsearch_opendistro_destination_test.go
+++ b/es/data_source_elasticsearch_opendistro_destination_test.go
@@ -18,11 +18,8 @@ func TestAccElasticsearchDataSourceDestination_basic(t *testing.T) {
 	}
 	meta := provider.Meta()
 	var allowed bool
-	esClient, err := getClient(meta.(*ProviderConf))
-	if err != nil {
-		t.Skipf("err: %s", err)
-	}
-	switch esClient.(type) {
+
+	switch meta.(type) {
 	case *elastic5.Client:
 		allowed = false
 	default:

--- a/es/data_source_elasticsearch_opendistro_destination_test.go
+++ b/es/data_source_elasticsearch_opendistro_destination_test.go
@@ -17,9 +17,12 @@ func TestAccElasticsearchDataSourceDestination_basic(t *testing.T) {
 		t.Skipf("err: %s", err)
 	}
 	meta := provider.Meta()
+	esClient, err := getClient(meta.(*ProviderConf))
+	if err != nil {
+		t.Skipf("err: %s", err)
+	}
 	var allowed bool
-
-	switch meta.(type) {
+	switch esClient.(type) {
 	case *elastic5.Client:
 		allowed = false
 	default:

--- a/es/data_source_elasticsearch_opendistro_destination_test.go
+++ b/es/data_source_elasticsearch_opendistro_destination_test.go
@@ -18,7 +18,11 @@ func TestAccElasticsearchDataSourceDestination_basic(t *testing.T) {
 	}
 	meta := provider.Meta()
 	var allowed bool
-	switch meta.(type) {
+	esClient, err := getClient(meta.(*ProviderConf))
+	if err != nil {
+		t.Skipf("err: %s", err)
+	}
+	switch esClient.(type) {
 	case *elastic5.Client:
 		allowed = false
 	default:

--- a/es/provider.go
+++ b/es/provider.go
@@ -27,6 +27,27 @@ import (
 
 var awsUrlRegexp = regexp.MustCompile(`([a-z0-9-]+).es.amazonaws.com$`)
 
+type ProviderConf struct {
+	rawUrl             string
+	insecure           bool
+	sniffing           bool
+	healthchecking     bool
+	cacertFile         string
+	username           string
+	password           string
+	parsedUrl          *url.URL
+	signAWSRequests    bool
+	esVersion          string
+	awsRegion          string
+	awsAssumeRoleArn   string
+	awsAccessKeyId     string
+	awsSecretAccessKey string
+	awsSessionToken    string
+	awsProfile         string
+	certPemPath        string
+	keyPemPath         string
+}
+
 func Provider() terraform.ResourceProvider {
 	return &schema.Provider{
 		Schema: map[string]*schema.Schema{
@@ -180,42 +201,57 @@ func Provider() terraform.ResourceProvider {
 
 func providerConfigure(d *schema.ResourceData) (interface{}, error) {
 	rawUrl := d.Get("url").(string)
-	insecure := d.Get("insecure").(bool)
-	sniffing := d.Get("sniff").(bool)
-	healthchecking := d.Get("healthcheck").(bool)
-	cacertFile := d.Get("cacert_file").(string)
-	username := d.Get("username").(string)
-	password := d.Get("password").(string)
 	parsedUrl, err := url.Parse(rawUrl)
-	signAWSRequests := d.Get("sign_aws_requests").(bool)
-	esVersion := d.Get("elasticsearch_version").(string)
 	if err != nil {
 		return nil, err
 	}
 
+	return &ProviderConf{
+		rawUrl:          rawUrl,
+		insecure:        d.Get("insecure").(bool),
+		sniffing:        d.Get("sniff").(bool),
+		healthchecking:  d.Get("healthcheck").(bool),
+		cacertFile:      d.Get("cacert_file").(string),
+		username:        d.Get("username").(string),
+		password:        d.Get("password").(string),
+		parsedUrl:       parsedUrl,
+		signAWSRequests: d.Get("sign_aws_requests").(bool),
+		esVersion:       d.Get("elasticsearch_version").(string),
+		awsRegion:       d.Get("aws_region").(string),
+
+		awsAssumeRoleArn:   d.Get("aws_assume_role_arn").(string),
+		awsAccessKeyId:     d.Get("aws_access_key").(string),
+		awsSecretAccessKey: d.Get("aws_secret_key").(string),
+		awsSessionToken:    d.Get("aws_token").(string),
+		awsProfile:         d.Get("aws_profile").(string),
+		certPemPath:        d.Get("client_cert_path").(string),
+		keyPemPath:         d.Get("client_key_path").(string),
+	}, nil
+}
+func getClient(conf *ProviderConf) (interface{}, error) {
 	opts := []elastic7.ClientOptionFunc{
-		elastic7.SetURL(rawUrl),
-		elastic7.SetScheme(parsedUrl.Scheme),
-		elastic7.SetSniff(sniffing),
-		elastic7.SetHealthcheck(healthchecking),
+		elastic7.SetURL(conf.rawUrl),
+		elastic7.SetScheme(conf.parsedUrl.Scheme),
+		elastic7.SetSniff(conf.sniffing),
+		elastic7.SetHealthcheck(conf.healthchecking),
 	}
 
-	if parsedUrl.User.Username() != "" {
-		p, _ := parsedUrl.User.Password()
-		opts = append(opts, elastic7.SetBasicAuth(parsedUrl.User.Username(), p))
+	if conf.parsedUrl.User.Username() != "" {
+		p, _ := conf.parsedUrl.User.Password()
+		opts = append(opts, elastic7.SetBasicAuth(conf.parsedUrl.User.Username(), p))
 	}
-	if username != "" && password != "" {
-		opts = append(opts, elastic7.SetBasicAuth(username, password))
+	if conf.username != "" && conf.password != "" {
+		opts = append(opts, elastic7.SetBasicAuth(conf.username, conf.password))
 	}
 
-	if m := awsUrlRegexp.FindStringSubmatch(parsedUrl.Hostname()); m != nil && signAWSRequests {
+	if m := awsUrlRegexp.FindStringSubmatch(conf.parsedUrl.Hostname()); m != nil && conf.signAWSRequests {
 		log.Printf("[INFO] Using AWS: %+v", m[1])
-		opts = append(opts, elastic7.SetHttpClient(awsHttpClient(m[1], d)), elastic7.SetSniff(false))
-	} else if awsRegion := d.Get("aws_region").(string); awsRegion != "" && signAWSRequests {
+		opts = append(opts, elastic7.SetHttpClient(awsHttpClient(m[1], conf)), elastic7.SetSniff(false))
+	} else if awsRegion := conf.awsRegion; conf.awsRegion != "" && conf.signAWSRequests {
 		log.Printf("[INFO] Using AWS: %+v", awsRegion)
-		opts = append(opts, elastic7.SetHttpClient(awsHttpClient(awsRegion, d)), elastic7.SetSniff(false))
-	} else if insecure || cacertFile != "" {
-		opts = append(opts, elastic7.SetHttpClient(tlsHttpClient(d)), elastic7.SetSniff(false))
+		opts = append(opts, elastic7.SetHttpClient(awsHttpClient(awsRegion, conf)), elastic7.SetSniff(false))
+	} else if conf.insecure || conf.cacertFile != "" {
+		opts = append(opts, elastic7.SetHttpClient(tlsHttpClient(conf)), elastic7.SetSniff(false))
 	}
 
 	var relevantClient interface{}
@@ -226,75 +262,75 @@ func providerConfigure(d *schema.ResourceData) (interface{}, error) {
 	relevantClient = client
 
 	// Use the v7 client to ping the cluster to determine the version if one was not provided
-	if esVersion == "" {
-		log.Printf("[INFO] Pinging url to determine version %+v", rawUrl)
-		info, _, err := client.Ping(rawUrl).Do(context.TODO())
+	if conf.esVersion == "" {
+		log.Printf("[INFO] Pinging url to determine version %+v", conf.rawUrl)
+		info, _, err := client.Ping(conf.rawUrl).Do(context.TODO())
 		if err != nil {
 			return nil, err
 		}
-		esVersion = info.Version.Number
+		conf.esVersion = info.Version.Number
 	}
 
-	if esVersion < "7.0.0" && esVersion >= "6.0.0" {
+	if conf.esVersion < "7.0.0" && conf.esVersion >= "6.0.0" {
 		log.Printf("[INFO] Using ES 6")
 		opts := []elastic6.ClientOptionFunc{
-			elastic6.SetURL(rawUrl),
-			elastic6.SetScheme(parsedUrl.Scheme),
-			elastic6.SetSniff(sniffing),
-			elastic6.SetHealthcheck(healthchecking),
+			elastic6.SetURL(conf.rawUrl),
+			elastic6.SetScheme(conf.parsedUrl.Scheme),
+			elastic6.SetSniff(conf.sniffing),
+			elastic6.SetHealthcheck(conf.healthchecking),
 		}
 
-		if parsedUrl.User.Username() != "" {
-			p, _ := parsedUrl.User.Password()
-			opts = append(opts, elastic6.SetBasicAuth(parsedUrl.User.Username(), p))
+		if conf.parsedUrl.User.Username() != "" {
+			p, _ := conf.parsedUrl.User.Password()
+			opts = append(opts, elastic6.SetBasicAuth(conf.parsedUrl.User.Username(), p))
 		}
-		if username != "" && password != "" {
-			opts = append(opts, elastic6.SetBasicAuth(username, password))
+		if conf.username != "" && conf.password != "" {
+			opts = append(opts, elastic6.SetBasicAuth(conf.username, conf.password))
 		}
 
-		if m := awsUrlRegexp.FindStringSubmatch(parsedUrl.Hostname()); m != nil && signAWSRequests {
+		if m := awsUrlRegexp.FindStringSubmatch(conf.parsedUrl.Hostname()); m != nil && conf.signAWSRequests {
 			log.Printf("[INFO] Using AWS: %+v", m[1])
-			opts = append(opts, elastic6.SetHttpClient(awsHttpClient(m[1], d)), elastic6.SetSniff(false))
-		} else if awsRegion := d.Get("aws_region").(string); awsRegion != "" && signAWSRequests {
-			log.Printf("[INFO] Using AWS: %+v", awsRegion)
-			opts = append(opts, elastic6.SetHttpClient(awsHttpClient(awsRegion, d)), elastic6.SetSniff(false))
-		} else if insecure || cacertFile != "" {
-			opts = append(opts, elastic6.SetHttpClient(tlsHttpClient(d)), elastic6.SetSniff(false))
+			opts = append(opts, elastic6.SetHttpClient(awsHttpClient(m[1], conf)), elastic6.SetSniff(false))
+		} else if awsRegion := conf.awsRegion; conf.awsRegion != "" && conf.signAWSRequests {
+			log.Printf("[INFO] Using AWS: %+v", conf.awsRegion)
+			opts = append(opts, elastic6.SetHttpClient(awsHttpClient(awsRegion, conf)), elastic6.SetSniff(false))
+		} else if conf.insecure || conf.cacertFile != "" {
+			opts = append(opts, elastic6.SetHttpClient(tlsHttpClient(conf)), elastic6.SetSniff(false))
 		}
 		relevantClient, err = elastic6.NewClient(opts...)
 		if err != nil {
 			return nil, err
 		}
-	} else if esVersion < "6.0.0" && esVersion >= "5.0.0" {
+	} else if conf.esVersion < "6.0.0" && conf.esVersion >= "5.0.0" {
 		log.Printf("[INFO] Using ES 5")
 		opts := []elastic5.ClientOptionFunc{
-			elastic5.SetURL(rawUrl),
-			elastic5.SetScheme(parsedUrl.Scheme),
-			elastic5.SetSniff(sniffing),
-			elastic5.SetHealthcheck(healthchecking),
+			elastic5.SetURL(conf.rawUrl),
+			elastic5.SetScheme(conf.parsedUrl.Scheme),
+			elastic5.SetSniff(conf.sniffing),
+			elastic5.SetHealthcheck(conf.healthchecking),
 		}
 
-		if parsedUrl.User.Username() != "" {
-			p, _ := parsedUrl.User.Password()
-			opts = append(opts, elastic5.SetBasicAuth(parsedUrl.User.Username(), p))
+		if conf.parsedUrl.User.Username() != "" {
+			p, _ := conf.parsedUrl.User.Password()
+			opts = append(opts, elastic5.SetBasicAuth(conf.parsedUrl.User.Username(), p))
 		}
-		if username != "" && password != "" {
-			opts = append(opts, elastic5.SetBasicAuth(username, password))
+		if conf.username != "" && conf.password != "" {
+			opts = append(opts, elastic5.SetBasicAuth(conf.username, conf.password))
 		}
 
-		if m := awsUrlRegexp.FindStringSubmatch(parsedUrl.Hostname()); m != nil && signAWSRequests {
-			opts = append(opts, elastic5.SetHttpClient(awsHttpClient(m[1], d)), elastic5.SetSniff(false))
-		} else if awsRegion := d.Get("aws_region").(string); awsRegion != "" && signAWSRequests {
-			log.Printf("[INFO] Using AWS: %+v", awsRegion)
-			opts = append(opts, elastic5.SetHttpClient(awsHttpClient(awsRegion, d)), elastic5.SetSniff(false))
-		} else if insecure || cacertFile != "" {
-			opts = append(opts, elastic5.SetHttpClient(tlsHttpClient(d)), elastic5.SetSniff(false))
+		if m := awsUrlRegexp.FindStringSubmatch(conf.parsedUrl.Hostname()); m != nil && conf.signAWSRequests {
+			opts = append(opts, elastic5.SetHttpClient(awsHttpClient(m[1], conf)), elastic5.SetSniff(false))
+		} else if awsRegion := conf.awsRegion; conf.awsRegion != "" && conf.signAWSRequests {
+			log.Printf("[INFO] Using AWS: %+v", conf.awsRegion)
+			opts = append(opts, elastic5.SetHttpClient(awsHttpClient(awsRegion, conf)), elastic5.SetSniff(false))
+		} else if conf.insecure || conf.cacertFile != "" {
+			opts = append(opts, elastic5.SetHttpClient(tlsHttpClient(conf)), elastic5.SetSniff(false))
 		}
 		relevantClient, err = elastic5.NewClient(opts...)
 		if err != nil {
 			return nil, err
 		}
-	} else if esVersion < "5.0.0" {
+	} else if conf.esVersion < "5.0.0" {
 		return nil, errors.New("ElasticSearch is older than 5.0.0!")
 	}
 
@@ -317,15 +353,7 @@ func assumeRoleCredentials(region, roleARN, profile string) *awscredentials.Cred
 	return awscredentials.NewChainCredentials([]awscredentials.Provider{assumeRoleProvider})
 }
 
-func awsSession(region string, d *schema.ResourceData) *awssession.Session {
-	insecure := d.Get("insecure").(bool)
-
-	awsAssumeRoleArn := d.Get("aws_assume_role_arn").(string)
-	awsAccessKeyId := d.Get("aws_access_key").(string)
-	awsSecretAccessKey := d.Get("aws_secret_key").(string)
-	awsSessionToken := d.Get("aws_token").(string)
-	awsProfile := d.Get("aws_profile").(string)
-
+func awsSession(region string, conf *ProviderConf) *awssession.Session {
 	sessOpts := awssession.Options{
 		Config: aws.Config{
 			Region: aws.String(region),
@@ -337,16 +365,16 @@ func awsSession(region string, d *schema.ResourceData) *awssession.Session {
 	// 4. let the default credentials provider figure out the rest (env, ec2, etc..)
 	//
 	// note: if #1 is chosen, then no further providers will be tested, since we've overridden the credentials with just a static provider
-	if awsAccessKeyId != "" {
-		sessOpts.Config.Credentials = awscredentials.NewStaticCredentials(awsAccessKeyId, awsSecretAccessKey, awsSessionToken)
-	} else if awsAssumeRoleArn != "" {
-		sessOpts.Config.Credentials = assumeRoleCredentials(region, awsAssumeRoleArn, awsProfile)
-	} else if awsProfile != "" {
-		sessOpts.Profile = awsProfile
+	if conf.awsAccessKeyId != "" {
+		sessOpts.Config.Credentials = awscredentials.NewStaticCredentials(conf.awsAccessKeyId, conf.awsSecretAccessKey, conf.awsSessionToken)
+	} else if conf.awsAssumeRoleArn != "" {
+		sessOpts.Config.Credentials = assumeRoleCredentials(region, conf.awsAssumeRoleArn, conf.awsProfile)
+	} else if conf.awsProfile != "" {
+		sessOpts.Profile = conf.awsProfile
 	}
 
 	// If configured as insecure, turn off SSL verification
-	if insecure {
+	if conf.insecure {
 		client := &http.Client{Transport: &http.Transport{
 			TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
 		}}
@@ -356,27 +384,23 @@ func awsSession(region string, d *schema.ResourceData) *awssession.Session {
 	return awssession.Must(awssession.NewSessionWithOptions(sessOpts))
 }
 
-func awsHttpClient(region string, d *schema.ResourceData) *http.Client {
-	signer := awssigv4.NewSigner(awsSession(region, d).Config.Credentials)
+func awsHttpClient(region string, conf *ProviderConf) *http.Client {
+	signer := awssigv4.NewSigner(awsSession(region, conf).Config.Credentials)
 	client, _ := aws_signing_client.New(signer, nil, "es", region)
 
 	return client
 }
 
-func tlsHttpClient(d *schema.ResourceData) *http.Client {
-	insecure := d.Get("insecure").(bool)
-	cacertFile := d.Get("cacert_file").(string)
-	certPemPath := d.Get("client_cert_path").(string)
-	keyPemPath := d.Get("client_key_path").(string)
+func tlsHttpClient(conf *ProviderConf) *http.Client {
 
 	// Configure TLS/SSL
 	tlsConfig := &tls.Config{}
-	if certPemPath != "" && keyPemPath != "" {
-		certPem, _, err := pathorcontents.Read(certPemPath)
+	if conf.certPemPath != "" && conf.keyPemPath != "" {
+		certPem, _, err := pathorcontents.Read(conf.certPemPath)
 		if err != nil {
 			log.Fatal(err)
 		}
-		keyPem, _, err := pathorcontents.Read(keyPemPath)
+		keyPem, _, err := pathorcontents.Read(conf.keyPemPath)
 		if err != nil {
 			log.Fatal(err)
 		}
@@ -388,8 +412,8 @@ func tlsHttpClient(d *schema.ResourceData) *http.Client {
 	}
 
 	// If a cacertFile has been specified, use that for cert validation
-	if cacertFile != "" {
-		caCert, _, _ := pathorcontents.Read(cacertFile)
+	if conf.cacertFile != "" {
+		caCert, _, _ := pathorcontents.Read(conf.cacertFile)
 
 		caCertPool := x509.NewCertPool()
 		caCertPool.AppendCertsFromPEM([]byte(caCert))
@@ -397,7 +421,7 @@ func tlsHttpClient(d *schema.ResourceData) *http.Client {
 	}
 
 	// If configured as insecure, turn off SSL verification
-	if insecure {
+	if conf.insecure {
 		tlsConfig.InsecureSkipVerify = true
 	}
 

--- a/es/provider_test.go
+++ b/es/provider_test.go
@@ -189,15 +189,19 @@ func TestAWSCredsAssumeRole(t *testing.T) {
 	}
 
 	testConfigData := schema.TestResourceDataRaw(t, Provider().(*schema.Provider).Schema, testConfig)
-	s := awsSession(testRegion, testConfigData)
+
+	conf := &ProviderConf{
+		awsAssumeRoleArn: testConfigData.Get("aws_assume_role_arn").(string),
+	}
+	s := awsSession(testRegion, conf)
 	if s == nil {
 		t.Fatalf("awsSession returned nil")
 	}
 }
 
 func getCreds(t *testing.T, region string, config map[string]interface{}) credentials.Value {
-	testConfigData := schema.TestResourceDataRaw(t, Provider().(*schema.Provider).Schema, config)
-	s := awsSession(region, testConfigData)
+	conf := &ProviderConf{}
+	s := awsSession(region, conf)
 	if s == nil {
 		t.Fatalf("awsSession returned nil")
 	}

--- a/es/provider_test.go
+++ b/es/provider_test.go
@@ -200,7 +200,24 @@ func TestAWSCredsAssumeRole(t *testing.T) {
 }
 
 func getCreds(t *testing.T, region string, config map[string]interface{}) credentials.Value {
-	conf := &ProviderConf{}
+	awsAccessKey := ""
+	awsSecretKey := ""
+	awsProfile := ""
+	if val, ok := config["aws_access_key"]; ok {
+		awsAccessKey = val.(string)
+	}
+	if val, ok := config["aws_secret_key"]; ok {
+		awsSecretKey = val.(string)
+	}
+	if val, ok := config["aws_profile"]; ok {
+		awsProfile = val.(string)
+	}
+
+	conf := &ProviderConf{
+		awsAccessKeyId:     awsAccessKey,
+		awsSecretAccessKey: awsSecretKey,
+		awsProfile:         awsProfile,
+	}
 	s := awsSession(region, conf)
 	if s == nil {
 		t.Fatalf("awsSession returned nil")

--- a/es/resource_elasticsearch_index.go
+++ b/es/resource_elasticsearch_index.go
@@ -162,7 +162,11 @@ func resourceElasticsearchIndexCreate(d *schema.ResourceData, meta interface{}) 
 
 	// Note: the CreateIndex call handles URL encoding under the hood to handle
 	// non-URL friendly characters and functionality like date math
-	switch client := meta.(type) {
+	esClient, err := getClient(meta.(*ProviderConf))
+	if err != nil {
+		return err
+	}
+	switch client := esClient.(type) {
 	case *elastic7.Client:
 		resp, requestErr := client.CreateIndex(name).BodyJson(body).Do(ctx)
 		err = requestErr
@@ -231,7 +235,11 @@ func resourceElasticsearchIndexDelete(d *schema.ResourceData, meta interface{}) 
 		return fmt.Errorf("There are documents in the index (or the index could not be , set force_destroy to true to allow destroying.")
 	}
 
-	switch client := meta.(type) {
+	esClient, err := getClient(meta.(*ProviderConf))
+	if err != nil {
+		return err
+	}
+	switch client := esClient.(type) {
 	case *elastic7.Client:
 		_, err = client.DeleteIndex(name).Do(ctx)
 
@@ -254,7 +262,11 @@ func allowIndexDestroy(indexName string, d *schema.ResourceData, meta interface{
 		count int64
 		err   error
 	)
-	switch client := meta.(type) {
+	esClient, err := getClient(meta.(*ProviderConf))
+	if err != nil {
+		return false
+	}
+	switch client := esClient.(type) {
 	case *elastic7.Client:
 		count, err = client.Count(indexName).Do(ctx)
 
@@ -304,7 +316,11 @@ func resourceElasticsearchIndexUpdate(d *schema.ResourceData, meta interface{}) 
 		name = getWriteIndexByAlias(alias.(string), d, meta)
 	}
 
-	switch client := meta.(type) {
+	esClient, err := getClient(meta.(*ProviderConf))
+	if err != nil {
+		return err
+	}
+	switch client := esClient.(type) {
 	case *elastic7.Client:
 		_, err = client.IndexPutSettings(name).BodyJson(body).Do(ctx)
 
@@ -329,7 +345,12 @@ func getWriteIndexByAlias(alias string, d *schema.ResourceData, meta interface{}
 		columns = []string{"index", "is_write_index"}
 	)
 
-	switch client := meta.(type) {
+	esClient, err := getClient(meta.(*ProviderConf))
+	if err != nil {
+		log.Printf("[INFO] getWriteIndexByAlias: %+v", err)
+		return index
+	}
+	switch client := esClient.(type) {
 	case *elastic7.Client:
 		r, err := client.CatAliases().Alias(alias).Columns(columns...).Do(ctx)
 		if err != nil {
@@ -383,7 +404,11 @@ func resourceElasticsearchIndexRead(d *schema.ResourceData, meta interface{}) er
 	}
 
 	// The logic is repeated strictly because of the types
-	switch client := meta.(type) {
+	esClient, err := getClient(meta.(*ProviderConf))
+	if err != nil {
+		return err
+	}
+	switch client := esClient.(type) {
 	case *elastic7.Client:
 		r, err := client.IndexGet(index).Do(ctx)
 		if err != nil {

--- a/es/resource_elasticsearch_index.go
+++ b/es/resource_elasticsearch_index.go
@@ -182,7 +182,7 @@ func resourceElasticsearchIndexCreate(d *schema.ResourceData, meta interface{}) 
 		}
 
 	default:
-		elastic5Client := meta.(*elastic5.Client)
+		elastic5Client := client.(*elastic5.Client)
 		resp, requestErr := elastic5Client.CreateIndex(name).BodyJson(body).Do(ctx)
 		err = requestErr
 		if err == nil {
@@ -247,7 +247,7 @@ func resourceElasticsearchIndexDelete(d *schema.ResourceData, meta interface{}) 
 		_, err = client.DeleteIndex(name).Do(ctx)
 
 	default:
-		elastic5Client := meta.(*elastic5.Client)
+		elastic5Client := client.(*elastic5.Client)
 		_, err = elastic5Client.DeleteIndex(name).Do(ctx)
 	}
 
@@ -274,7 +274,7 @@ func allowIndexDestroy(indexName string, d *schema.ResourceData, meta interface{
 		count, err = client.Count(indexName).Do(ctx)
 
 	default:
-		elastic5Client := meta.(*elastic5.Client)
+		elastic5Client := client.(*elastic5.Client)
 		count, err = elastic5Client.Count(indexName).Do(ctx)
 	}
 
@@ -328,12 +328,12 @@ func resourceElasticsearchIndexUpdate(d *schema.ResourceData, meta interface{}) 
 		_, err = client.IndexPutSettings(name).BodyJson(body).Do(ctx)
 
 	default:
-		elastic5Client := meta.(*elastic5.Client)
+		elastic5Client := client.(*elastic5.Client)
 		_, err = elastic5Client.IndexPutSettings(name).BodyJson(body).Do(ctx)
 	}
 
 	if err == nil {
-		return resourceElasticsearchIndexRead(d, meta)
+		return resourceElasticsearchIndexRead(d, meta.(*ProviderConf))
 	}
 	return err
 }
@@ -376,7 +376,7 @@ func getWriteIndexByAlias(alias string, d *schema.ResourceData, meta interface{}
 		}
 
 	default:
-		elastic5Client := meta.(*elastic5.Client)
+		elastic5Client := client.(*elastic5.Client)
 		r, err := elastic5Client.CatAliases().Alias(alias).Columns(columns...).Do(ctx)
 		if err != nil {
 			log.Printf("[INFO] getWriteIndexByAlias: %+v", err)
@@ -428,7 +428,7 @@ func resourceElasticsearchIndexRead(d *schema.ResourceData, meta interface{}) er
 			settings = resp.Settings["index"].(map[string]interface{})
 		}
 	default:
-		elastic5Client := meta.(*elastic5.Client)
+		elastic5Client := client.(*elastic5.Client)
 		r, err := elastic5Client.IndexGet(index).Do(ctx)
 		if err != nil {
 			return err

--- a/es/resource_elasticsearch_index_template.go
+++ b/es/resource_elasticsearch_index_template.go
@@ -182,7 +182,7 @@ func resourceElasticsearchPutIndexTemplate(d *schema.ResourceData, meta interfac
 	case *elastic6.Client:
 		err = elastic6IndexPutTemplate(client, name, body, create)
 	default:
-		elastic5Client := meta.(*elastic5.Client)
+		elastic5Client := client.(*elastic5.Client)
 		err = elastic5IndexPutTemplate(elastic5Client, name, body, create)
 	}
 

--- a/es/resource_elasticsearch_index_template.go
+++ b/es/resource_elasticsearch_index_template.go
@@ -141,7 +141,7 @@ func resourceElasticsearchIndexTemplateDelete(d *schema.ResourceData, meta inter
 	case *elastic6.Client:
 		err = elastic6IndexDeleteTemplate(client, id)
 	default:
-		elastic5Client := meta.(*elastic5.Client)
+		elastic5Client := client.(*elastic5.Client)
 		err = elastic5IndexDeleteTemplate(elastic5Client, id)
 	}
 

--- a/es/resource_elasticsearch_index_template.go
+++ b/es/resource_elasticsearch_index_template.go
@@ -51,13 +51,17 @@ func resourceElasticsearchIndexTemplateRead(d *schema.ResourceData, meta interfa
 
 	var result string
 	var err error
-	switch client := meta.(type) {
+	esClient, err := getClient(meta.(*ProviderConf))
+	if err != nil {
+		return err
+	}
+	switch client := esClient.(type) {
 	case *elastic7.Client:
 		result, err = elastic7IndexGetTemplate(client, id)
 	case *elastic6.Client:
 		result, err = elastic6IndexGetTemplate(client, id)
 	default:
-		elastic5Client := meta.(*elastic5.Client)
+		elastic5Client := esClient.(*elastic5.Client)
 		result, err = elastic5IndexGetTemplate(elastic5Client, id)
 	}
 	if err != nil {
@@ -127,7 +131,11 @@ func resourceElasticsearchIndexTemplateDelete(d *schema.ResourceData, meta inter
 	id := d.Id()
 
 	var err error
-	switch client := meta.(type) {
+	esClient, err := getClient(meta.(*ProviderConf))
+	if err != nil {
+		return err
+	}
+	switch client := esClient.(type) {
 	case *elastic7.Client:
 		err = elastic7IndexDeleteTemplate(client, id)
 	case *elastic6.Client:
@@ -164,7 +172,11 @@ func resourceElasticsearchPutIndexTemplate(d *schema.ResourceData, meta interfac
 	body := d.Get("body").(string)
 
 	var err error
-	switch client := meta.(type) {
+	esClient, err := getClient(meta.(*ProviderConf))
+	if err != nil {
+		return err
+	}
+	switch client := esClient.(type) {
 	case *elastic7.Client:
 		err = elastic7IndexPutTemplate(client, name, body, create)
 	case *elastic6.Client:

--- a/es/resource_elasticsearch_index_template_test.go
+++ b/es/resource_elasticsearch_index_template_test.go
@@ -22,11 +22,7 @@ func TestAccElasticsearchIndexTemplate(t *testing.T) {
 	}
 	meta := provider.Meta()
 	var config string
-	esClient, err := getClient(meta.(*ProviderConf))
-	if err != nil {
-		t.Skipf("err: %s", err)
-	}
-	switch esClient.(type) {
+	switch meta.(type) {
 	case *elastic7.Client:
 		config = testAccElasticsearchIndexTemplateV7
 	case *elastic6.Client:
@@ -59,11 +55,7 @@ func TestAccElasticsearchIndexTemplate_importBasic(t *testing.T) {
 	}
 	meta := provider.Meta()
 	var config string
-	esClient, err := getClient(meta.(*ProviderConf))
-	if err != nil {
-		t.Skipf("err: %s", err)
-	}
-	switch esClient.(type) {
+	switch meta.(type) {
 	case *elastic7.Client:
 		config = testAccElasticsearchIndexTemplateV7
 	case *elastic6.Client:
@@ -114,7 +106,7 @@ func testCheckElasticsearchIndexTemplateExists(name string) resource.TestCheckFu
 		case *elastic6.Client:
 			_, err = client.IndexGetTemplate(rs.Primary.ID).Do(context.TODO())
 		default:
-			elastic5Client := meta.(*elastic5.Client)
+			elastic5Client := client.(*elastic5.Client)
 			_, err = elastic5Client.IndexGetTemplate(rs.Primary.ID).Do(context.TODO())
 		}
 
@@ -145,7 +137,7 @@ func testCheckElasticsearchIndexTemplateDestroy(s *terraform.State) error {
 		case *elastic6.Client:
 			_, err = client.IndexGetTemplate(rs.Primary.ID).Do(context.TODO())
 		default:
-			elastic5Client := meta.(*elastic5.Client)
+			elastic5Client := client.(*elastic5.Client)
 			_, err = elastic5Client.IndexGetTemplate(rs.Primary.ID).Do(context.TODO())
 		}
 

--- a/es/resource_elasticsearch_index_template_test.go
+++ b/es/resource_elasticsearch_index_template_test.go
@@ -21,8 +21,12 @@ func TestAccElasticsearchIndexTemplate(t *testing.T) {
 		t.Skipf("err: %s", err)
 	}
 	meta := provider.Meta()
+	esClient, err := getClient(meta.(*ProviderConf))
+	if err != nil {
+		t.Skipf("err: %s", err)
+	}
 	var config string
-	switch meta.(type) {
+	switch esClient.(type) {
 	case *elastic7.Client:
 		config = testAccElasticsearchIndexTemplateV7
 	case *elastic6.Client:
@@ -55,7 +59,11 @@ func TestAccElasticsearchIndexTemplate_importBasic(t *testing.T) {
 	}
 	meta := provider.Meta()
 	var config string
-	switch meta.(type) {
+	esClient, err := getClient(meta.(*ProviderConf))
+	if err != nil {
+		t.Skipf("err: %s", err)
+	}
+	switch esClient.(type) {
 	case *elastic7.Client:
 		config = testAccElasticsearchIndexTemplateV7
 	case *elastic6.Client:

--- a/es/resource_elasticsearch_index_template_test.go
+++ b/es/resource_elasticsearch_index_template_test.go
@@ -22,7 +22,11 @@ func TestAccElasticsearchIndexTemplate(t *testing.T) {
 	}
 	meta := provider.Meta()
 	var config string
-	switch meta.(type) {
+	esClient, err := getClient(meta.(*ProviderConf))
+	if err != nil {
+		t.Skipf("err: %s", err)
+	}
+	switch esClient.(type) {
 	case *elastic7.Client:
 		config = testAccElasticsearchIndexTemplateV7
 	case *elastic6.Client:
@@ -55,7 +59,11 @@ func TestAccElasticsearchIndexTemplate_importBasic(t *testing.T) {
 	}
 	meta := provider.Meta()
 	var config string
-	switch meta.(type) {
+	esClient, err := getClient(meta.(*ProviderConf))
+	if err != nil {
+		t.Skipf("err: %s", err)
+	}
+	switch esClient.(type) {
 	case *elastic7.Client:
 		config = testAccElasticsearchIndexTemplateV7
 	case *elastic6.Client:
@@ -96,7 +104,11 @@ func testCheckElasticsearchIndexTemplateExists(name string) resource.TestCheckFu
 		meta := testAccProvider.Meta()
 
 		var err error
-		switch client := meta.(type) {
+		esClient, err := getClient(meta.(*ProviderConf))
+		if err != nil {
+			return err
+		}
+		switch client := esClient.(type) {
 		case *elastic7.Client:
 			_, err = client.IndexGetTemplate(rs.Primary.ID).Do(context.TODO())
 		case *elastic6.Client:
@@ -123,7 +135,11 @@ func testCheckElasticsearchIndexTemplateDestroy(s *terraform.State) error {
 		meta := testAccProvider.Meta()
 
 		var err error
-		switch client := meta.(type) {
+		esClient, err := getClient(meta.(*ProviderConf))
+		if err != nil {
+			return err
+		}
+		switch client := esClient.(type) {
 		case *elastic7.Client:
 			_, err = client.IndexGetTemplate(rs.Primary.ID).Do(context.TODO())
 		case *elastic6.Client:

--- a/es/resource_elasticsearch_index_test.go
+++ b/es/resource_elasticsearch_index_test.go
@@ -216,11 +216,7 @@ func TestAccElasticsearchIndex_handleInvalid(t *testing.T) {
 	}
 	meta := provider.Meta()
 	var allowed bool
-	esClient, err := getClient(meta.(*ProviderConf))
-	if err != nil {
-		t.Skipf("err: %s", err)
-	}
-	switch esClient.(type) {
+	switch meta.(type) {
 	case *elastic5.Client:
 		allowed = false
 	default:
@@ -291,11 +287,8 @@ func TestAccElasticsearchIndex_rolloverAliasXpack(t *testing.T) {
 	}
 	meta := provider.Meta()
 	var allowed bool
-	esClient, err := getClient(meta.(*ProviderConf))
-	if err != nil {
-		t.Skipf("err: %s", err)
-	}
-	switch esClient.(type) {
+
+	switch meta.(type) {
 	case *elastic5.Client:
 		allowed = false
 	default:
@@ -340,11 +333,8 @@ func TestAccElasticsearchIndex_rolloverAliasOpendistro(t *testing.T) {
 	}
 	meta := provider.Meta()
 	var allowed bool
-	esClient, err := getClient(meta.(*ProviderConf))
-	if err != nil {
-		t.Skipf("err: %s", err)
-	}
-	switch esClient.(type) {
+
+	switch meta.(type) {
 	case *elastic6.Client:
 		allowed = false
 	case *elastic5.Client:
@@ -406,7 +396,7 @@ func checkElasticsearchIndexExists(name string) resource.TestCheckFunc {
 		case *elastic6.Client:
 			_, err = client.IndexGetSettings(rs.Primary.ID).Do(context.TODO())
 		default:
-			elastic5Client := meta.(*elastic5.Client)
+			elastic5Client := client.(*elastic5.Client)
 			_, err = elastic5Client.IndexGetSettings(rs.Primary.ID).Do(context.TODO())
 		}
 
@@ -448,7 +438,7 @@ func checkElasticsearchIndexUpdated(name string) resource.TestCheckFunc {
 			settings = resp[rs.Primary.ID].Settings["index"].(map[string]interface{})
 
 		default:
-			elastic5Client := meta.(*elastic5.Client)
+			elastic5Client := client.(*elastic5.Client)
 			resp, err := elastic5Client.IndexGetSettings(rs.Primary.ID).Do(context.TODO())
 			if err != nil {
 				return err
@@ -488,7 +478,7 @@ func checkElasticsearchIndexDestroy(s *terraform.State) error {
 		case *elastic6.Client:
 			_, err = client.IndexGetSettings(rs.Primary.ID).Do(context.TODO())
 		default:
-			elastic5Client := meta.(*elastic5.Client)
+			elastic5Client := client.(*elastic5.Client)
 			_, err = elastic5Client.IndexGetSettings(rs.Primary.ID).Do(context.TODO())
 		}
 
@@ -525,7 +515,7 @@ func checkElasticsearchIndexRolloverAliasExists(provider *schema.Provider, alias
 			}
 			count = len(r)
 		default:
-			elastic5Client := meta.(*elastic5.Client)
+			elastic5Client := client.(*elastic5.Client)
 			r, err := elastic5Client.CatAliases().Alias(alias).Do(context.TODO())
 			if err != nil {
 				return err
@@ -578,7 +568,7 @@ func checkElasticsearchIndexRolloverAliasDestroy(provider *schema.Provider, alia
 			}
 			count = len(r)
 		default:
-			elastic5Client := meta.(*elastic5.Client)
+			elastic5Client := client.(*elastic5.Client)
 			r, err := elastic5Client.CatAliases().Alias(alias).Do(context.TODO())
 			if err != nil {
 				return err

--- a/es/resource_elasticsearch_index_test.go
+++ b/es/resource_elasticsearch_index_test.go
@@ -215,8 +215,12 @@ func TestAccElasticsearchIndex_handleInvalid(t *testing.T) {
 		t.Skipf("err: %s", err)
 	}
 	meta := provider.Meta()
+	esClient, err := getClient(meta.(*ProviderConf))
+	if err != nil {
+		t.Skipf("err: %s", err)
+	}
 	var allowed bool
-	switch meta.(type) {
+	switch esClient.(type) {
 	case *elastic5.Client:
 		allowed = false
 	default:
@@ -286,9 +290,13 @@ func TestAccElasticsearchIndex_rolloverAliasXpack(t *testing.T) {
 		t.Skipf("err: %s", err)
 	}
 	meta := provider.Meta()
+	esClient, err := getClient(meta.(*ProviderConf))
+	if err != nil {
+		t.Skipf("err: %s", err)
+	}
 	var allowed bool
 
-	switch meta.(type) {
+	switch esClient.(type) {
 	case *elastic5.Client:
 		allowed = false
 	default:
@@ -332,9 +340,13 @@ func TestAccElasticsearchIndex_rolloverAliasOpendistro(t *testing.T) {
 		t.Skipf("err: %s", err)
 	}
 	meta := provider.Meta()
+	esClient, err := getClient(meta.(*ProviderConf))
+	if err != nil {
+		t.Skipf("err: %s", err)
+	}
 	var allowed bool
 
-	switch meta.(type) {
+	switch esClient.(type) {
 	case *elastic6.Client:
 		allowed = false
 	case *elastic5.Client:

--- a/es/resource_elasticsearch_index_test.go
+++ b/es/resource_elasticsearch_index_test.go
@@ -216,7 +216,11 @@ func TestAccElasticsearchIndex_handleInvalid(t *testing.T) {
 	}
 	meta := provider.Meta()
 	var allowed bool
-	switch meta.(type) {
+	esClient, err := getClient(meta.(*ProviderConf))
+	if err != nil {
+		t.Skipf("err: %s", err)
+	}
+	switch esClient.(type) {
 	case *elastic5.Client:
 		allowed = false
 	default:
@@ -287,7 +291,11 @@ func TestAccElasticsearchIndex_rolloverAliasXpack(t *testing.T) {
 	}
 	meta := provider.Meta()
 	var allowed bool
-	switch meta.(type) {
+	esClient, err := getClient(meta.(*ProviderConf))
+	if err != nil {
+		t.Skipf("err: %s", err)
+	}
+	switch esClient.(type) {
 	case *elastic5.Client:
 		allowed = false
 	default:
@@ -332,7 +340,11 @@ func TestAccElasticsearchIndex_rolloverAliasOpendistro(t *testing.T) {
 	}
 	meta := provider.Meta()
 	var allowed bool
-	switch meta.(type) {
+	esClient, err := getClient(meta.(*ProviderConf))
+	if err != nil {
+		t.Skipf("err: %s", err)
+	}
+	switch esClient.(type) {
 	case *elastic6.Client:
 		allowed = false
 	case *elastic5.Client:
@@ -384,7 +396,11 @@ func checkElasticsearchIndexExists(name string) resource.TestCheckFunc {
 		meta := testAccProvider.Meta()
 
 		var err error
-		switch client := meta.(type) {
+		esClient, err := getClient(meta.(*ProviderConf))
+		if err != nil {
+			return err
+		}
+		switch client := esClient.(type) {
 		case *elastic7.Client:
 			_, err = client.IndexGetSettings(rs.Primary.ID).Do(context.TODO())
 		case *elastic6.Client:
@@ -411,7 +427,12 @@ func checkElasticsearchIndexUpdated(name string) resource.TestCheckFunc {
 		meta := testAccProvider.Meta()
 		var settings map[string]interface{}
 
-		switch client := meta.(type) {
+		var err error
+		esClient, err := getClient(meta.(*ProviderConf))
+		if err != nil {
+			return err
+		}
+		switch client := esClient.(type) {
 		case *elastic7.Client:
 			resp, err := client.IndexGetSettings(rs.Primary.ID).Do(context.TODO())
 			if err != nil {
@@ -457,7 +478,11 @@ func checkElasticsearchIndexDestroy(s *terraform.State) error {
 		meta := testAccProvider.Meta()
 
 		var err error
-		switch client := meta.(type) {
+		esClient, err := getClient(meta.(*ProviderConf))
+		if err != nil {
+			return err
+		}
+		switch client := esClient.(type) {
 		case *elastic7.Client:
 			_, err = client.IndexGetSettings(rs.Primary.ID).Do(context.TODO())
 		case *elastic6.Client:
@@ -482,7 +507,11 @@ func checkElasticsearchIndexRolloverAliasExists(provider *schema.Provider, alias
 		meta := provider.Meta()
 
 		var count int
-		switch client := meta.(type) {
+		esClient, err := getClient(meta.(*ProviderConf))
+		if err != nil {
+			return err
+		}
+		switch client := esClient.(type) {
 		case *elastic7.Client:
 			r, err := client.CatAliases().Alias(alias).Do(context.TODO())
 			if err != nil {
@@ -531,7 +560,11 @@ func checkElasticsearchIndexRolloverAliasDestroy(provider *schema.Provider, alia
 		meta := provider.Meta()
 
 		var count int
-		switch client := meta.(type) {
+		esClient, err := getClient(meta.(*ProviderConf))
+		if err != nil {
+			return err
+		}
+		switch client := esClient.(type) {
 		case *elastic7.Client:
 			r, err := client.CatAliases().Alias(alias).Do(context.TODO())
 			if err != nil {

--- a/es/resource_elasticsearch_ingest_pipeline.go
+++ b/es/resource_elasticsearch_ingest_pipeline.go
@@ -61,7 +61,7 @@ func resourceElasticsearchIngestPipelineRead(d *schema.ResourceData, meta interf
 	case *elastic6.Client:
 		result, err = elastic6IngestGetPipeline(client, id)
 	default:
-		elastic5Client := meta.(*elastic5.Client)
+		elastic5Client := client.(*elastic5.Client)
 		result, err = elastic5IngestGetPipeline(elastic5Client, id)
 	}
 	if err != nil {
@@ -138,7 +138,7 @@ func resourceElasticsearchIngestPipelineDelete(d *schema.ResourceData, meta inte
 	case *elastic6.Client:
 		_, err = client.IngestDeletePipeline(id).Do(context.TODO())
 	default:
-		elastic5Client := meta.(*elastic5.Client)
+		elastic5Client := client.(*elastic5.Client)
 		_, err = elastic5Client.IngestDeletePipeline(id).Do(context.TODO())
 	}
 
@@ -164,7 +164,7 @@ func resourceElasticsearchPutIngestPipeline(d *schema.ResourceData, meta interfa
 	case *elastic6.Client:
 		_, err = client.IngestPutPipeline(name).BodyString(body).Do(context.TODO())
 	default:
-		elastic5Client := meta.(*elastic5.Client)
+		elastic5Client := client.(*elastic5.Client)
 		_, err = elastic5Client.IngestPutPipeline(name).BodyString(body).Do(context.TODO())
 	}
 

--- a/es/resource_elasticsearch_ingest_pipeline.go
+++ b/es/resource_elasticsearch_ingest_pipeline.go
@@ -51,7 +51,11 @@ func resourceElasticsearchIngestPipelineRead(d *schema.ResourceData, meta interf
 
 	var result string
 	var err error
-	switch client := meta.(type) {
+	esClient, err := getClient(meta.(*ProviderConf))
+	if err != nil {
+		return err
+	}
+	switch client := esClient.(type) {
 	case *elastic7.Client:
 		result, err = elastic7IngestGetPipeline(client, id)
 	case *elastic6.Client:
@@ -124,7 +128,11 @@ func resourceElasticsearchIngestPipelineDelete(d *schema.ResourceData, meta inte
 	id := d.Id()
 
 	var err error
-	switch client := meta.(type) {
+	esClient, err := getClient(meta.(*ProviderConf))
+	if err != nil {
+		return err
+	}
+	switch client := esClient.(type) {
 	case *elastic7.Client:
 		_, err = client.IngestDeletePipeline(id).Do(context.TODO())
 	case *elastic6.Client:
@@ -146,7 +154,11 @@ func resourceElasticsearchPutIngestPipeline(d *schema.ResourceData, meta interfa
 	body := d.Get("body").(string)
 
 	var err error
-	switch client := meta.(type) {
+	esClient, err := getClient(meta.(*ProviderConf))
+	if err != nil {
+		return err
+	}
+	switch client := esClient.(type) {
 	case *elastic7.Client:
 		_, err = client.IngestPutPipeline(name).BodyString(body).Do(context.TODO())
 	case *elastic6.Client:

--- a/es/resource_elasticsearch_ingest_pipeline_test.go
+++ b/es/resource_elasticsearch_ingest_pipeline_test.go
@@ -21,9 +21,13 @@ func TestAccElasticsearchIngestPipeline(t *testing.T) {
 		t.Skipf("err: %s", err)
 	}
 	meta := provider.Meta()
+	esClient, err := getClient(meta.(*ProviderConf))
+	if err != nil {
+		t.Skipf("err: %s", err)
+	}
 	var config string
 
-	switch meta.(type) {
+	switch esClient.(type) {
 	case *elastic7.Client:
 		config = testAccElasticsearchIngestPipelineV7
 	case *elastic6.Client:
@@ -55,8 +59,12 @@ func TestAccElasticsearchIngestPipeline_importBasic(t *testing.T) {
 		t.Skipf("err: %s", err)
 	}
 	meta := provider.Meta()
+	esClient, err := getClient(meta.(*ProviderConf))
+	if err != nil {
+		t.Skipf("err: %s", err)
+	}
 	var config string
-	switch meta.(type) {
+	switch esClient.(type) {
 	case *elastic7.Client:
 		config = testAccElasticsearchIngestPipelineV7
 	case *elastic6.Client:

--- a/es/resource_elasticsearch_ingest_pipeline_test.go
+++ b/es/resource_elasticsearch_ingest_pipeline_test.go
@@ -22,7 +22,11 @@ func TestAccElasticsearchIngestPipeline(t *testing.T) {
 	}
 	meta := provider.Meta()
 	var config string
-	switch meta.(type) {
+	esClient, err := getClient(meta.(*ProviderConf))
+	if err != nil {
+		t.Skipf("err: %s", err)
+	}
+	switch esClient.(type) {
 	case *elastic7.Client:
 		config = testAccElasticsearchIngestPipelineV7
 	case *elastic6.Client:
@@ -55,7 +59,11 @@ func TestAccElasticsearchIngestPipeline_importBasic(t *testing.T) {
 	}
 	meta := provider.Meta()
 	var config string
-	switch meta.(type) {
+	esClient, err := getClient(meta.(*ProviderConf))
+	if err != nil {
+		t.Skipf("err: %s", err)
+	}
+	switch esClient.(type) {
 	case *elastic7.Client:
 		config = testAccElasticsearchIngestPipelineV7
 	case *elastic6.Client:
@@ -96,7 +104,11 @@ func testCheckElasticsearchIngestPipelineExists(name string) resource.TestCheckF
 		meta := testAccProvider.Meta()
 
 		var err error
-		switch client := meta.(type) {
+		esClient, err := getClient(meta.(*ProviderConf))
+		if err != nil {
+			return err
+		}
+		switch client := esClient.(type) {
 		case *elastic7.Client:
 			_, err = client.IngestGetPipeline(rs.Primary.ID).Do(context.TODO())
 		case *elastic6.Client:
@@ -123,7 +135,11 @@ func testCheckElasticsearchIngestPipelineDestroy(s *terraform.State) error {
 		meta := testAccProvider.Meta()
 
 		var err error
-		switch client := meta.(type) {
+		esClient, err := getClient(meta.(*ProviderConf))
+		if err != nil {
+			return err
+		}
+		switch client := esClient.(type) {
 		case *elastic7.Client:
 			_, err = client.IngestGetPipeline(rs.Primary.ID).Do(context.TODO())
 		case *elastic6.Client:

--- a/es/resource_elasticsearch_ingest_pipeline_test.go
+++ b/es/resource_elasticsearch_ingest_pipeline_test.go
@@ -22,11 +22,8 @@ func TestAccElasticsearchIngestPipeline(t *testing.T) {
 	}
 	meta := provider.Meta()
 	var config string
-	esClient, err := getClient(meta.(*ProviderConf))
-	if err != nil {
-		t.Skipf("err: %s", err)
-	}
-	switch esClient.(type) {
+
+	switch meta.(type) {
 	case *elastic7.Client:
 		config = testAccElasticsearchIngestPipelineV7
 	case *elastic6.Client:
@@ -59,11 +56,7 @@ func TestAccElasticsearchIngestPipeline_importBasic(t *testing.T) {
 	}
 	meta := provider.Meta()
 	var config string
-	esClient, err := getClient(meta.(*ProviderConf))
-	if err != nil {
-		t.Skipf("err: %s", err)
-	}
-	switch esClient.(type) {
+	switch meta.(type) {
 	case *elastic7.Client:
 		config = testAccElasticsearchIngestPipelineV7
 	case *elastic6.Client:
@@ -114,7 +107,7 @@ func testCheckElasticsearchIngestPipelineExists(name string) resource.TestCheckF
 		case *elastic6.Client:
 			_, err = client.IngestGetPipeline(rs.Primary.ID).Do(context.TODO())
 		default:
-			elastic5Client := meta.(*elastic5.Client)
+			elastic5Client := client.(*elastic5.Client)
 			_, err = elastic5Client.IngestGetPipeline(rs.Primary.ID).Do(context.TODO())
 		}
 
@@ -145,7 +138,7 @@ func testCheckElasticsearchIngestPipelineDestroy(s *terraform.State) error {
 		case *elastic6.Client:
 			_, err = client.IngestGetPipeline(rs.Primary.ID).Do(context.TODO())
 		default:
-			elastic5Client := meta.(*elastic5.Client)
+			elastic5Client := client.(*elastic5.Client)
 			_, err = elastic5Client.IngestGetPipeline(rs.Primary.ID).Do(context.TODO())
 		}
 

--- a/es/resource_elasticsearch_kibana_object.go
+++ b/es/resource_elasticsearch_kibana_object.go
@@ -89,7 +89,7 @@ func resourceElasticsearchKibanaObjectCreate(d *schema.ResourceData, meta interf
 	case *elastic6.Client:
 		success, err = elastic6CreateIndexIfNotExists(client, index, mapping_index)
 	default:
-		elastic5Client := meta.(*elastic5.Client)
+		elastic5Client := client.(*elastic5.Client)
 		success, err = elastic5CreateIndexIfNotExists(elastic5Client, index, mapping_index)
 	}
 
@@ -213,7 +213,7 @@ func resourceElasticsearchKibanaObjectRead(d *schema.ResourceData, meta interfac
 	case *elastic6.Client:
 		result, err = elastic6GetObject(client, objectType, index, id)
 	default:
-		elastic5Client := meta.(*elastic5.Client)
+		elastic5Client := client.(*elastic5.Client)
 		result, err = elastic5GetObject(elastic5Client, objectType, index, id)
 	}
 
@@ -262,7 +262,7 @@ func resourceElasticsearchKibanaObjectDelete(d *schema.ResourceData, meta interf
 	case *elastic6.Client:
 		err = elastic6DeleteIndex(client, objectType, index, id)
 	default:
-		elastic5Client := meta.(*elastic5.Client)
+		elastic5Client := client.(*elastic5.Client)
 		err = elastic5DeleteIndex(elastic5Client, objectType, index, id)
 	}
 
@@ -329,7 +329,7 @@ func resourceElasticsearchPutKibanaObject(d *schema.ResourceData, meta interface
 	case *elastic6.Client:
 		err = elastic6PutIndex(client, objectType, index, id, data)
 	default:
-		elastic5Client := meta.(*elastic5.Client)
+		elastic5Client := client.(*elastic5.Client)
 		err = elastic5PutIndex(elastic5Client, objectType, index, id, data)
 	}
 

--- a/es/resource_elasticsearch_kibana_object.go
+++ b/es/resource_elasticsearch_kibana_object.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/structure"
+
 	// "github.com/hashicorp/terraform-plugin-sdk/helper/validation"
 
 	elastic7 "github.com/olivere/elastic/v7"
@@ -78,7 +79,11 @@ func resourceElasticsearchKibanaObjectCreate(d *schema.ResourceData, meta interf
 
 	var success int
 	var err error
-	switch client := meta.(type) {
+	esClient, err := getClient(meta.(*ProviderConf))
+	if err != nil {
+		return err
+	}
+	switch client := esClient.(type) {
 	case *elastic7.Client:
 		success, err = elastic7CreateIndexIfNotExists(client, index, mapping_index)
 	case *elastic6.Client:
@@ -198,7 +203,11 @@ func resourceElasticsearchKibanaObjectRead(d *schema.ResourceData, meta interfac
 
 	var result *json.RawMessage
 	var err error
-	switch client := meta.(type) {
+	esClient, err := getClient(meta.(*ProviderConf))
+	if err != nil {
+		return err
+	}
+	switch client := esClient.(type) {
 	case *elastic7.Client:
 		result, err = elastic7GetObject(client, index, id)
 	case *elastic6.Client:
@@ -243,7 +252,11 @@ func resourceElasticsearchKibanaObjectDelete(d *schema.ResourceData, meta interf
 	index := d.Get("index").(string)
 
 	var err error
-	switch client := meta.(type) {
+	esClient, err := getClient(meta.(*ProviderConf))
+	if err != nil {
+		return err
+	}
+	switch client := esClient.(type) {
 	case *elastic7.Client:
 		err = elastic7DeleteIndex(client, index, id)
 	case *elastic6.Client:
@@ -306,7 +319,11 @@ func resourceElasticsearchPutKibanaObject(d *schema.ResourceData, meta interface
 	index := d.Get("index").(string)
 
 	var err error
-	switch client := meta.(type) {
+	esClient, err := getClient(meta.(*ProviderConf))
+	if err != nil {
+		return "", err
+	}
+	switch client := esClient.(type) {
 	case *elastic7.Client:
 		err = elastic7PutIndex(client, index, id, data)
 	case *elastic6.Client:

--- a/es/resource_elasticsearch_kibana_object_test.go
+++ b/es/resource_elasticsearch_kibana_object_test.go
@@ -27,8 +27,11 @@ func TestAccElasticsearchKibanaObject(t *testing.T) {
 	var visualizationConfig string
 	var indexPatternConfig string
 	meta := testAccProvider.Meta()
-
-	switch meta.(type) {
+	esClient, err := getClient(meta.(*ProviderConf))
+	if err != nil {
+		t.Skipf("err: %s", err)
+	}
+	switch esClient.(type) {
 	case *elastic7.Client:
 		visualizationConfig = testAccElasticsearch7KibanaVisualization
 		indexPatternConfig = testAccElasticsearch7KibanaIndexPattern
@@ -86,9 +89,13 @@ func TestAccElasticsearchKibanaObject_Rejected(t *testing.T) {
 		t.Skipf("err: %s", err)
 	}
 	meta := provider.Meta()
+	esClient, err := getClient(meta.(*ProviderConf))
+	if err != nil {
+		t.Skipf("err: %s", err)
+	}
 	var allowed bool
 
-	switch meta.(type) {
+	switch esClient.(type) {
 	case *elastic6.Client:
 		allowed = true
 	default:

--- a/es/resource_elasticsearch_kibana_object_test.go
+++ b/es/resource_elasticsearch_kibana_object_test.go
@@ -27,7 +27,11 @@ func TestAccElasticsearchKibanaObject(t *testing.T) {
 	var visualizationConfig string
 	var indexPatternConfig string
 	meta := testAccProvider.Meta()
-	switch meta.(type) {
+	esClient, err := getClient(meta.(*ProviderConf))
+	if err != nil {
+		t.Skipf("err: %s", err)
+	}
+	switch esClient.(type) {
 	case *elastic7.Client:
 		visualizationConfig = testAccElasticsearch7KibanaVisualization
 		indexPatternConfig = testAccElasticsearch7KibanaIndexPattern
@@ -86,7 +90,11 @@ func TestAccElasticsearchKibanaObject_Rejected(t *testing.T) {
 	}
 	meta := provider.Meta()
 	var allowed bool
-	switch meta.(type) {
+	esClient, err := getClient(meta.(*ProviderConf))
+	if err != nil {
+		t.Skipf("err: %s", err)
+	}
+	switch esClient.(type) {
 	case *elastic6.Client:
 		allowed = true
 	default:
@@ -124,7 +132,11 @@ func testCheckElasticsearchKibanaObjectExists(name string, objectType string, id
 		meta := testAccProvider.Meta()
 
 		var err error
-		switch client := meta.(type) {
+		esClient, err := getClient(meta.(*ProviderConf))
+		if err != nil {
+			return err
+		}
+		switch client := esClient.(type) {
 		case *elastic7.Client:
 			_, err = client.Get().Index(".kibana").Id(id).Do(context.TODO())
 		case *elastic6.Client:
@@ -152,7 +164,11 @@ func testCheckElasticsearchKibanaObjectDestroy(s *terraform.State) error {
 		meta := testAccProvider.Meta()
 
 		var err error
-		switch client := meta.(type) {
+		esClient, err := getClient(meta.(*ProviderConf))
+		if err != nil {
+			return err
+		}
+		switch client := esClient.(type) {
 		case *elastic7.Client:
 			_, err = client.Get().Index(".kibana").Id("response-time-percentile").Do(context.TODO())
 		case *elastic6.Client:

--- a/es/resource_elasticsearch_kibana_object_test.go
+++ b/es/resource_elasticsearch_kibana_object_test.go
@@ -27,11 +27,8 @@ func TestAccElasticsearchKibanaObject(t *testing.T) {
 	var visualizationConfig string
 	var indexPatternConfig string
 	meta := testAccProvider.Meta()
-	esClient, err := getClient(meta.(*ProviderConf))
-	if err != nil {
-		t.Skipf("err: %s", err)
-	}
-	switch esClient.(type) {
+
+	switch meta.(type) {
 	case *elastic7.Client:
 		visualizationConfig = testAccElasticsearch7KibanaVisualization
 		indexPatternConfig = testAccElasticsearch7KibanaIndexPattern
@@ -90,11 +87,8 @@ func TestAccElasticsearchKibanaObject_Rejected(t *testing.T) {
 	}
 	meta := provider.Meta()
 	var allowed bool
-	esClient, err := getClient(meta.(*ProviderConf))
-	if err != nil {
-		t.Skipf("err: %s", err)
-	}
-	switch esClient.(type) {
+
+	switch meta.(type) {
 	case *elastic6.Client:
 		allowed = true
 	default:
@@ -142,7 +136,7 @@ func testCheckElasticsearchKibanaObjectExists(name string, objectType string, id
 		case *elastic6.Client:
 			_, err = client.Get().Index(".kibana").Type(deprecatedDocType).Id(id).Do(context.TODO())
 		default:
-			elastic5Client := meta.(*elastic5.Client)
+			elastic5Client := client.(*elastic5.Client)
 			_, err = elastic5Client.Get().Index(".kibana").Type(objectType).Id(id).Do(context.TODO())
 		}
 
@@ -174,7 +168,7 @@ func testCheckElasticsearchKibanaObjectDestroy(s *terraform.State) error {
 		case *elastic6.Client:
 			_, err = client.Get().Index(".kibana").Type("visualization").Id("response-time-percentile").Do(context.TODO())
 		default:
-			elastic5Client := meta.(*elastic5.Client)
+			elastic5Client := client.(*elastic5.Client)
 			_, err = elastic5Client.Get().Index(".kibana").Type("visualization").Id("response-time-percentile").Do(context.TODO())
 		}
 

--- a/es/resource_elasticsearch_opendistro_destination.go
+++ b/es/resource_elasticsearch_opendistro_destination.go
@@ -108,7 +108,11 @@ func resourceElasticsearchOpenDistroDestinationDelete(d *schema.ResourceData, m 
 		return fmt.Errorf("error building URL path for destination: %+v", err)
 	}
 
-	switch client := m.(type) {
+	esClient, err := getClient(m.(*ProviderConf))
+	if err != nil {
+		return err
+	}
+	switch client := esClient.(type) {
 	case *elastic7.Client:
 		_, err = client.PerformRequest(context.TODO(), elastic7.PerformRequestOptions{
 			Method: "DELETE",
@@ -132,7 +136,11 @@ func resourceElasticsearchOpenDistroGetDestination(destinationID string, m inter
 
 	// See https://github.com/opendistro-for-elasticsearch/alerting/issues/56, no API endpoint for retrieving destination
 	var body *json.RawMessage
-	switch client := m.(type) {
+	esClient, err := getClient(m.(*ProviderConf))
+	if err != nil {
+		return "", err
+	}
+	switch client := esClient.(type) {
 	case *elastic7.Client:
 		body, err = elastic7GetObject(client, DESTINATION_INDEX, destinationID)
 	case *elastic6.Client:
@@ -166,7 +174,11 @@ func resourceElasticsearchOpenDistroPostDestination(d *schema.ResourceData, m in
 	path := "/_opendistro/_alerting/destinations/"
 
 	var body json.RawMessage
-	switch client := m.(type) {
+	esClient, err := getClient(m.(*ProviderConf))
+	if err != nil {
+		return nil, err
+	}
+	switch client := esClient.(type) {
 	case *elastic7.Client:
 		var res *elastic7.Response
 		res, err = client.PerformRequest(context.TODO(), elastic7.PerformRequestOptions{
@@ -212,7 +224,11 @@ func resourceElasticsearchOpenDistroPutDestination(d *schema.ResourceData, m int
 	}
 
 	var body json.RawMessage
-	switch client := m.(type) {
+	esClient, err := getClient(m.(*ProviderConf))
+	if err != nil {
+		return nil, err
+	}
+	switch client := esClient.(type) {
 	case *elastic7.Client:
 		var res *elastic7.Response
 		res, err = client.PerformRequest(context.TODO(), elastic7.PerformRequestOptions{

--- a/es/resource_elasticsearch_opendistro_destination_test.go
+++ b/es/resource_elasticsearch_opendistro_destination_test.go
@@ -21,11 +21,8 @@ func TestAccElasticsearchOpenDistroDestination(t *testing.T) {
 	}
 	meta := provider.Meta()
 	var allowed bool
-	esClient, err := getClient(meta.(*ProviderConf))
-	if err != nil {
-		t.Skipf("err: %s", err)
-	}
-	switch esClient.(type) {
+
+	switch meta.(type) {
 	case *elastic5.Client:
 		allowed = false
 	default:
@@ -60,11 +57,8 @@ func TestAccElasticsearchOpenDistroDestination_importBasic(t *testing.T) {
 	}
 	meta := provider.Meta()
 	var allowed bool
-	esClient, err := getClient(meta.(*ProviderConf))
-	if err != nil {
-		t.Skipf("err: %s", err)
-	}
-	switch esClient.(type) {
+
+	switch meta.(type) {
 	case *elastic5.Client:
 		allowed = false
 	default:

--- a/es/resource_elasticsearch_opendistro_destination_test.go
+++ b/es/resource_elasticsearch_opendistro_destination_test.go
@@ -106,17 +106,7 @@ func testCheckElasticsearchOpenDistroDestinationExists(name string) resource.Tes
 		meta := testAccOpendistroProvider.Meta()
 
 		var err error
-		esClient, err := getClient(meta.(*ProviderConf))
-		if err != nil {
-			return err
-		}
-		switch client := esClient.(type) {
-		case *elastic7.Client:
-			_, err = resourceElasticsearchOpenDistroGetDestination(rs.Primary.ID, client)
-		case *elastic6.Client:
-			_, err = resourceElasticsearchOpenDistroGetDestination(rs.Primary.ID, client)
-		default:
-		}
+		_, err = resourceElasticsearchOpenDistroGetDestination(rs.Primary.ID, meta.(*ProviderConf))
 
 		if err != nil {
 			return err

--- a/es/resource_elasticsearch_opendistro_destination_test.go
+++ b/es/resource_elasticsearch_opendistro_destination_test.go
@@ -20,9 +20,13 @@ func TestAccElasticsearchOpenDistroDestination(t *testing.T) {
 		t.Skipf("err: %s", err)
 	}
 	meta := provider.Meta()
+	esClient, err := getClient(meta.(*ProviderConf))
+	if err != nil {
+		t.Skipf("err: %s", err)
+	}
 	var allowed bool
 
-	switch meta.(type) {
+	switch esClient.(type) {
 	case *elastic5.Client:
 		allowed = false
 	default:
@@ -56,9 +60,13 @@ func TestAccElasticsearchOpenDistroDestination_importBasic(t *testing.T) {
 		t.Skipf("err: %s", err)
 	}
 	meta := provider.Meta()
+	esClient, err := getClient(meta.(*ProviderConf))
+	if err != nil {
+		t.Skipf("err: %s", err)
+	}
 	var allowed bool
 
-	switch meta.(type) {
+	switch esClient.(type) {
 	case *elastic5.Client:
 		allowed = false
 	default:
@@ -123,11 +131,11 @@ func testCheckElasticsearchOpenDistroDestinationDestroy(s *terraform.State) erro
 		if err != nil {
 			return err
 		}
-		switch client := esClient.(type) {
+		switch esClient.(type) {
 		case *elastic7.Client:
-			_, err = resourceElasticsearchOpenDistroGetDestination(rs.Primary.ID, client)
+			_, err = resourceElasticsearchOpenDistroGetDestination(rs.Primary.ID, meta.(*ProviderConf))
 		case *elastic6.Client:
-			_, err = resourceElasticsearchOpenDistroGetDestination(rs.Primary.ID, client)
+			_, err = resourceElasticsearchOpenDistroGetDestination(rs.Primary.ID, meta.(*ProviderConf))
 		default:
 		}
 

--- a/es/resource_elasticsearch_opendistro_destination_test.go
+++ b/es/resource_elasticsearch_opendistro_destination_test.go
@@ -21,7 +21,11 @@ func TestAccElasticsearchOpenDistroDestination(t *testing.T) {
 	}
 	meta := provider.Meta()
 	var allowed bool
-	switch meta.(type) {
+	esClient, err := getClient(meta.(*ProviderConf))
+	if err != nil {
+		t.Skipf("err: %s", err)
+	}
+	switch esClient.(type) {
 	case *elastic5.Client:
 		allowed = false
 	default:
@@ -56,7 +60,11 @@ func TestAccElasticsearchOpenDistroDestination_importBasic(t *testing.T) {
 	}
 	meta := provider.Meta()
 	var allowed bool
-	switch meta.(type) {
+	esClient, err := getClient(meta.(*ProviderConf))
+	if err != nil {
+		t.Skipf("err: %s", err)
+	}
+	switch esClient.(type) {
 	case *elastic5.Client:
 		allowed = false
 	default:
@@ -98,7 +106,11 @@ func testCheckElasticsearchOpenDistroDestinationExists(name string) resource.Tes
 		meta := testAccOpendistroProvider.Meta()
 
 		var err error
-		switch client := meta.(type) {
+		esClient, err := getClient(meta.(*ProviderConf))
+		if err != nil {
+			return err
+		}
+		switch client := esClient.(type) {
 		case *elastic7.Client:
 			_, err = resourceElasticsearchOpenDistroGetDestination(rs.Primary.ID, client)
 		case *elastic6.Client:
@@ -123,7 +135,11 @@ func testCheckElasticsearchOpenDistroDestinationDestroy(s *terraform.State) erro
 		meta := testAccOpendistroProvider.Meta()
 
 		var err error
-		switch client := meta.(type) {
+		esClient, err := getClient(meta.(*ProviderConf))
+		if err != nil {
+			return err
+		}
+		switch client := esClient.(type) {
 		case *elastic7.Client:
 			_, err = resourceElasticsearchOpenDistroGetDestination(rs.Primary.ID, client)
 		case *elastic6.Client:

--- a/es/resource_elasticsearch_opendistro_ism_policy.go
+++ b/es/resource_elasticsearch_opendistro_ism_policy.go
@@ -117,7 +117,11 @@ func resourceElasticsearchOpenDistroISMPolicyDelete(d *schema.ResourceData, m in
 		return fmt.Errorf("error building URL path for policy: %+v", err)
 	}
 
-	switch client := m.(type) {
+	esClient, err := getClient(m.(*ProviderConf))
+	if err != nil {
+		return err
+	}
+	switch client := esClient.(type) {
 	case *elastic7.Client:
 		_, err = client.PerformRequest(context.TODO(), elastic7.PerformRequestOptions{
 			Method: "DELETE",
@@ -147,7 +151,11 @@ func resourceElasticsearchGetOpenDistroISMPolicy(policyID string, m interface{})
 	}
 
 	var body *json.RawMessage
-	switch client := m.(type) {
+	esClient, err := getClient(m.(*ProviderConf))
+	if err != nil {
+		return *response, err
+	}
+	switch client := esClient.(type) {
 	case *elastic7.Client:
 		var res *elastic7.Response
 		res, err = client.PerformRequest(context.TODO(), elastic7.PerformRequestOptions{
@@ -196,7 +204,11 @@ func resourceElasticsearchPutOpenDistroISMPolicy(d *schema.ResourceData, m inter
 	}
 
 	var body *json.RawMessage
-	switch client := m.(type) {
+	esClient, err := getClient(m.(*ProviderConf))
+	if err != nil {
+		return nil, err
+	}
+	switch client := esClient.(type) {
 	case *elastic7.Client:
 		var res *elastic7.Response
 		res, err = client.PerformRequest(context.TODO(), elastic7.PerformRequestOptions{

--- a/es/resource_elasticsearch_opendistro_ism_policy_mapping.go
+++ b/es/resource_elasticsearch_opendistro_ism_policy_mapping.go
@@ -157,7 +157,11 @@ func resourceElasticsearchPostOpendistroPolicyMapping(d *schema.ResourceData, m 
 	}
 
 	var body *json.RawMessage
-	switch client := m.(type) {
+	esClient, err := getClient(m.(*ProviderConf))
+	if err != nil {
+		return nil, err
+	}
+	switch client := esClient.(type) {
 	case *elastic7.Client:
 		var res *elastic7.Response
 		res, err = client.PerformRequest(context.TODO(), elastic7.PerformRequestOptions{
@@ -195,7 +199,11 @@ func resourceElasticsearchGetOpendistroPolicyMapping(d *schema.ResourceData, m i
 	}
 
 	var body *json.RawMessage
-	switch client := m.(type) {
+	esClient, err := getClient(m.(*ProviderConf))
+	if err != nil {
+		return nil, err
+	}
+	switch client := esClient.(type) {
 	case *elastic7.Client:
 		var res *elastic7.Response
 		res, err = client.PerformRequest(context.TODO(), elastic7.PerformRequestOptions{

--- a/es/resource_elasticsearch_opendistro_ism_policy_test.go
+++ b/es/resource_elasticsearch_opendistro_ism_policy_test.go
@@ -20,9 +20,13 @@ func TestAccElasticsearchOpenDistroISMPolicy(t *testing.T) {
 		t.Skipf("err: %s", err)
 	}
 	meta := provider.Meta()
+	esClient, err := getClient(meta.(*ProviderConf))
+	if err != nil {
+		t.Skipf("err: %s", err)
+	}
 	var allowed bool
 
-	switch meta.(type) {
+	switch esClient.(type) {
 	case *elastic6.Client:
 		allowed = false
 	case *elastic5.Client:
@@ -73,9 +77,9 @@ func testCheckElasticsearchOpenDistroISMPolicyExists(name string) resource.TestC
 		if err != nil {
 			return err
 		}
-		switch client := esClient.(type) {
+		switch esClient.(type) {
 		case *elastic7.Client:
-			_, err = resourceElasticsearchGetOpenDistroISMPolicy(rs.Primary.ID, client)
+			_, err = resourceElasticsearchGetOpenDistroISMPolicy(rs.Primary.ID, meta.(*ProviderConf))
 		default:
 		}
 
@@ -100,9 +104,9 @@ func testCheckElasticsearchOpenDistroISMPolicyDestroy(s *terraform.State) error 
 		if err != nil {
 			return err
 		}
-		switch client := esClient.(type) {
+		switch esClient.(type) {
 		case *elastic7.Client:
-			_, err = resourceElasticsearchGetOpenDistroISMPolicy(rs.Primary.ID, client)
+			_, err = resourceElasticsearchGetOpenDistroISMPolicy(rs.Primary.ID, meta.(*ProviderConf))
 		default:
 		}
 

--- a/es/resource_elasticsearch_opendistro_ism_policy_test.go
+++ b/es/resource_elasticsearch_opendistro_ism_policy_test.go
@@ -21,7 +21,11 @@ func TestAccElasticsearchOpenDistroISMPolicy(t *testing.T) {
 	}
 	meta := provider.Meta()
 	var allowed bool
-	switch meta.(type) {
+	esClient, err := getClient(meta.(*ProviderConf))
+	if err != nil {
+		t.Skipf("err: %s", err)
+	}
+	switch esClient.(type) {
 	case *elastic6.Client:
 		allowed = false
 	case *elastic5.Client:
@@ -68,7 +72,11 @@ func testCheckElasticsearchOpenDistroISMPolicyExists(name string) resource.TestC
 		meta := testAccOpendistroProvider.Meta()
 
 		var err error
-		switch client := meta.(type) {
+		esClient, err := getClient(meta.(*ProviderConf))
+		if err != nil {
+			return err
+		}
+		switch client := esClient.(type) {
 		case *elastic7.Client:
 			_, err = resourceElasticsearchGetOpenDistroISMPolicy(rs.Primary.ID, client)
 		default:
@@ -91,7 +99,11 @@ func testCheckElasticsearchOpenDistroISMPolicyDestroy(s *terraform.State) error 
 		meta := testAccOpendistroProvider.Meta()
 
 		var err error
-		switch client := meta.(type) {
+		esClient, err := getClient(meta.(*ProviderConf))
+		if err != nil {
+			return err
+		}
+		switch client := esClient.(type) {
 		case *elastic7.Client:
 			_, err = resourceElasticsearchGetOpenDistroISMPolicy(rs.Primary.ID, client)
 		default:

--- a/es/resource_elasticsearch_opendistro_ism_policy_test.go
+++ b/es/resource_elasticsearch_opendistro_ism_policy_test.go
@@ -21,11 +21,8 @@ func TestAccElasticsearchOpenDistroISMPolicy(t *testing.T) {
 	}
 	meta := provider.Meta()
 	var allowed bool
-	esClient, err := getClient(meta.(*ProviderConf))
-	if err != nil {
-		t.Skipf("err: %s", err)
-	}
-	switch esClient.(type) {
+
+	switch meta.(type) {
 	case *elastic6.Client:
 		allowed = false
 	case *elastic5.Client:

--- a/es/resource_elasticsearch_opendistro_monitor.go
+++ b/es/resource_elasticsearch_opendistro_monitor.go
@@ -120,7 +120,11 @@ func resourceElasticsearchOpenDistroMonitorDelete(d *schema.ResourceData, m inte
 		return fmt.Errorf("error building URL path for monitor: %+v", err)
 	}
 
-	switch client := m.(type) {
+	esClient, err := getClient(m.(*ProviderConf))
+	if err != nil {
+		return err
+	}
+	switch client := esClient.(type) {
 	case *elastic7.Client:
 		_, err = client.PerformRequest(context.TODO(), elastic7.PerformRequestOptions{
 			Method: "DELETE",
@@ -150,7 +154,11 @@ func resourceElasticsearchOpenDistroGetMonitor(monitorID string, m interface{}) 
 	}
 
 	var body json.RawMessage
-	switch client := m.(type) {
+	esClient, err := getClient(m.(*ProviderConf))
+	if err != nil {
+		return nil, err
+	}
+	switch client := esClient.(type) {
 	case *elastic7.Client:
 		var res *elastic7.Response
 		res, err = client.PerformRequest(context.TODO(), elastic7.PerformRequestOptions{
@@ -189,7 +197,11 @@ func resourceElasticsearchOpenDistroPostMonitor(d *schema.ResourceData, m interf
 	path := "/_opendistro/_alerting/monitors/"
 
 	var body json.RawMessage
-	switch client := m.(type) {
+	esClient, err := getClient(m.(*ProviderConf))
+	if err != nil {
+		return nil, err
+	}
+	switch client := esClient.(type) {
 	case *elastic7.Client:
 		var res *elastic7.Response
 		res, err = client.PerformRequest(context.TODO(), elastic7.PerformRequestOptions{
@@ -235,7 +247,11 @@ func resourceElasticsearchOpenDistroPutMonitor(d *schema.ResourceData, m interfa
 	}
 
 	var body json.RawMessage
-	switch client := m.(type) {
+	esClient, err := getClient(m.(*ProviderConf))
+	if err != nil {
+		return nil, err
+	}
+	switch client := esClient.(type) {
 	case *elastic7.Client:
 		var res *elastic7.Response
 		res, err = client.PerformRequest(context.TODO(), elastic7.PerformRequestOptions{

--- a/es/resource_elasticsearch_opendistro_monitor_test.go
+++ b/es/resource_elasticsearch_opendistro_monitor_test.go
@@ -21,11 +21,8 @@ func TestAccElasticsearchOpenDistroMonitor(t *testing.T) {
 	}
 	meta := provider.Meta()
 	var allowed bool
-	esClient, err := getClient(meta.(*ProviderConf))
-	if err != nil {
-		t.Skipf("err: %s", err)
-	}
-	switch esClient.(type) {
+
+	switch meta.(type) {
 	case *elastic5.Client:
 		allowed = false
 	default:

--- a/es/resource_elasticsearch_opendistro_monitor_test.go
+++ b/es/resource_elasticsearch_opendistro_monitor_test.go
@@ -21,7 +21,11 @@ func TestAccElasticsearchOpenDistroMonitor(t *testing.T) {
 	}
 	meta := provider.Meta()
 	var allowed bool
-	switch meta.(type) {
+	esClient, err := getClient(meta.(*ProviderConf))
+	if err != nil {
+		t.Skipf("err: %s", err)
+	}
+	switch esClient.(type) {
 	case *elastic5.Client:
 		allowed = false
 	default:
@@ -61,7 +65,11 @@ func testCheckElasticsearchOpenDistroMonitorExists(name string) resource.TestChe
 		meta := testAccOpendistroProvider.Meta()
 
 		var err error
-		switch client := meta.(type) {
+		esClient, err := getClient(meta.(*ProviderConf))
+		if err != nil {
+			return err
+		}
+		switch client := esClient.(type) {
 		case *elastic7.Client:
 			_, err = resourceElasticsearchOpenDistroGetMonitor(rs.Primary.ID, client)
 		case *elastic6.Client:
@@ -86,7 +94,11 @@ func testCheckElasticsearchMonitorDestroy(s *terraform.State) error {
 		meta := testAccOpendistroProvider.Meta()
 
 		var err error
-		switch client := meta.(type) {
+		esClient, err := getClient(meta.(*ProviderConf))
+		if err != nil {
+			return err
+		}
+		switch client := esClient.(type) {
 		case *elastic7.Client:
 			_, err = resourceElasticsearchOpenDistroGetMonitor(rs.Primary.ID, client)
 

--- a/es/resource_elasticsearch_opendistro_monitor_test.go
+++ b/es/resource_elasticsearch_opendistro_monitor_test.go
@@ -20,9 +20,13 @@ func TestAccElasticsearchOpenDistroMonitor(t *testing.T) {
 		t.Skipf("err: %s", err)
 	}
 	meta := provider.Meta()
+	esClient, err := getClient(meta.(*ProviderConf))
+	if err != nil {
+		t.Skipf("err: %s", err)
+	}
 	var allowed bool
 
-	switch meta.(type) {
+	switch esClient.(type) {
 	case *elastic5.Client:
 		allowed = false
 	default:
@@ -66,11 +70,11 @@ func testCheckElasticsearchOpenDistroMonitorExists(name string) resource.TestChe
 		if err != nil {
 			return err
 		}
-		switch client := esClient.(type) {
+		switch esClient.(type) {
 		case *elastic7.Client:
-			_, err = resourceElasticsearchOpenDistroGetMonitor(rs.Primary.ID, client)
+			_, err = resourceElasticsearchOpenDistroGetMonitor(rs.Primary.ID, meta.(*ProviderConf))
 		case *elastic6.Client:
-			_, err = resourceElasticsearchOpenDistroGetMonitor(rs.Primary.ID, client)
+			_, err = resourceElasticsearchOpenDistroGetMonitor(rs.Primary.ID, meta.(*ProviderConf))
 		default:
 		}
 
@@ -95,12 +99,12 @@ func testCheckElasticsearchMonitorDestroy(s *terraform.State) error {
 		if err != nil {
 			return err
 		}
-		switch client := esClient.(type) {
+		switch esClient.(type) {
 		case *elastic7.Client:
-			_, err = resourceElasticsearchOpenDistroGetMonitor(rs.Primary.ID, client)
+			_, err = resourceElasticsearchOpenDistroGetMonitor(rs.Primary.ID, meta.(*ProviderConf))
 
 		case *elastic6.Client:
-			_, err = resourceElasticsearchOpenDistroGetMonitor(rs.Primary.ID, client)
+			_, err = resourceElasticsearchOpenDistroGetMonitor(rs.Primary.ID, meta.(*ProviderConf))
 		default:
 		}
 

--- a/es/resource_elasticsearch_opendistro_role.go
+++ b/es/resource_elasticsearch_opendistro_role.go
@@ -165,7 +165,11 @@ func resourceElasticsearchOpenDistroRoleDelete(d *schema.ResourceData, m interfa
 		return fmt.Errorf("error building URL path for role: %+v", err)
 	}
 
-	switch client := m.(type) {
+	esClient, err := getClient(m.(*ProviderConf))
+	if err != nil {
+		return err
+	}
+	switch client := esClient.(type) {
 	case *elastic7.Client:
 		_, err = client.PerformRequest(context.TODO(), elastic7.PerformRequestOptions{
 			Method: "DELETE",
@@ -191,7 +195,11 @@ func resourceElasticsearchGetOpenDistroRole(roleID string, m interface{}) (RoleB
 	}
 
 	var body json.RawMessage
-	switch client := m.(type) {
+	esClient, err := getClient(m.(*ProviderConf))
+	if err != nil {
+		return *role, err
+	}
+	switch client := esClient.(type) {
 	case *elastic7.Client:
 		var res *elastic7.Response
 		res, err = client.PerformRequest(context.TODO(), elastic7.PerformRequestOptions{
@@ -268,7 +276,11 @@ func resourceElasticsearchPutOpenDistroRole(d *schema.ResourceData, m interface{
 	}
 
 	var body json.RawMessage
-	switch client := m.(type) {
+	esClient, err := getClient(m.(*ProviderConf))
+	if err != nil {
+		return nil, err
+	}
+	switch client := esClient.(type) {
 	case *elastic7.Client:
 		var res *elastic7.Response
 		res, err = client.PerformRequest(context.TODO(), elastic7.PerformRequestOptions{

--- a/es/resource_elasticsearch_opendistro_role_test.go
+++ b/es/resource_elasticsearch_opendistro_role_test.go
@@ -23,7 +23,11 @@ func TestAccElasticsearchOpenDistroRole(t *testing.T) {
 	}
 	meta := provider.Meta()
 	var allowed bool
-	switch meta.(type) {
+	esClient, err := getClient(meta.(*ProviderConf))
+	if err != nil {
+		t.Skipf("err: %s", err)
+	}
+	switch esClient.(type) {
 	case *elastic5.Client:
 		allowed = false
 	case *elastic6.Client:
@@ -110,7 +114,11 @@ func testAccCheckElasticsearchOpenDistroRoleDestroy(s *terraform.State) error {
 		meta := testAccOpendistroProvider.Meta()
 
 		var err error
-		switch client := meta.(type) {
+		esClient, err := getClient(meta.(*ProviderConf))
+		if err != nil {
+			return err
+		}
+		switch client := esClient.(type) {
 		case *elastic7.Client:
 			_, err = resourceElasticsearchGetOpenDistroRole(rs.Primary.ID, client)
 		default:
@@ -135,7 +143,11 @@ func testCheckElasticSearchOpenDistroRoleExists(name string) resource.TestCheckF
 			meta := testAccOpendistroProvider.Meta()
 
 			var err error
-			switch client := meta.(type) {
+			esClient, err := getClient(meta.(*ProviderConf))
+			if err != nil {
+				return err
+			}
+			switch client := esClient.(type) {
 			case *elastic7.Client:
 				_, err = resourceElasticsearchGetOpenDistroRole(rs.Primary.ID, client)
 			default:

--- a/es/resource_elasticsearch_opendistro_role_test.go
+++ b/es/resource_elasticsearch_opendistro_role_test.go
@@ -22,8 +22,12 @@ func TestAccElasticsearchOpenDistroRole(t *testing.T) {
 		t.Skipf("err: %s", err)
 	}
 	meta := provider.Meta()
+	esClient, err := getClient(meta.(*ProviderConf))
+	if err != nil {
+		t.Skipf("err: %s", err)
+	}
 	var allowed bool
-	switch meta.(type) {
+	switch esClient.(type) {
 	case *elastic5.Client:
 		allowed = false
 	case *elastic6.Client:
@@ -114,9 +118,9 @@ func testAccCheckElasticsearchOpenDistroRoleDestroy(s *terraform.State) error {
 		if err != nil {
 			return err
 		}
-		switch client := esClient.(type) {
+		switch esClient.(type) {
 		case *elastic7.Client:
-			_, err = resourceElasticsearchGetOpenDistroRole(rs.Primary.ID, client)
+			_, err = resourceElasticsearchGetOpenDistroRole(rs.Primary.ID, meta.(*ProviderConf))
 		default:
 		}
 
@@ -143,9 +147,9 @@ func testCheckElasticSearchOpenDistroRoleExists(name string) resource.TestCheckF
 			if err != nil {
 				return err
 			}
-			switch client := esClient.(type) {
+			switch esClient.(type) {
 			case *elastic7.Client:
-				_, err = resourceElasticsearchGetOpenDistroRole(rs.Primary.ID, client)
+				_, err = resourceElasticsearchGetOpenDistroRole(rs.Primary.ID, meta.(*ProviderConf))
 			default:
 			}
 

--- a/es/resource_elasticsearch_opendistro_role_test.go
+++ b/es/resource_elasticsearch_opendistro_role_test.go
@@ -23,11 +23,7 @@ func TestAccElasticsearchOpenDistroRole(t *testing.T) {
 	}
 	meta := provider.Meta()
 	var allowed bool
-	esClient, err := getClient(meta.(*ProviderConf))
-	if err != nil {
-		t.Skipf("err: %s", err)
-	}
-	switch esClient.(type) {
+	switch meta.(type) {
 	case *elastic5.Client:
 		allowed = false
 	case *elastic6.Client:

--- a/es/resource_elasticsearch_opendistro_roles_mapping.go
+++ b/es/resource_elasticsearch_opendistro_roles_mapping.go
@@ -117,7 +117,11 @@ func resourceElasticsearchOpenDistroRolesMappingDelete(d *schema.ResourceData, m
 		return fmt.Errorf("error building URL path for role mapping: %+v", err)
 	}
 
-	switch client := m.(type) {
+	esClient, err := getClient(m.(*ProviderConf))
+	if err != nil {
+		return err
+	}
+	switch client := esClient.(type) {
 	case *elastic7.Client:
 		_, err = client.PerformRequest(context.TODO(), elastic7.PerformRequestOptions{
 			Method: "DELETE",
@@ -142,7 +146,11 @@ func resourceElasticsearchGetOpenDistroRolesMapping(roleID string, m interface{}
 		return *roleMapping, fmt.Errorf("error building URL path for role mapping: %+v", err)
 	}
 	var body json.RawMessage
-	switch client := m.(type) {
+	esClient, err := getClient(m.(*ProviderConf))
+	if err != nil {
+		return *roleMapping, err
+	}
+	switch client := esClient.(type) {
 	case *elastic7.Client:
 		var res *elastic7.Response
 		res, err = client.PerformRequest(context.TODO(), elastic7.PerformRequestOptions{
@@ -194,7 +202,11 @@ func resourceElasticsearchPutOpenDistroRolesMapping(d *schema.ResourceData, m in
 	}
 
 	var body json.RawMessage
-	switch client := m.(type) {
+	esClient, err := getClient(m.(*ProviderConf))
+	if err != nil {
+		return nil, err
+	}
+	switch client := esClient.(type) {
 	case *elastic7.Client:
 		var res *elastic7.Response
 		res, err = client.PerformRequest(context.TODO(), elastic7.PerformRequestOptions{

--- a/es/resource_elasticsearch_opendistro_roles_mapping_test.go
+++ b/es/resource_elasticsearch_opendistro_roles_mapping_test.go
@@ -23,7 +23,11 @@ func TestAccElasticsearchOpenDistroRolesMapping(t *testing.T) {
 	}
 	meta := provider.Meta()
 	var allowed bool
-	switch meta.(type) {
+	esClient, err := getClient(meta.(*ProviderConf))
+	if err != nil {
+		t.Skipf("err: %s", err)
+	}
+	switch esClient.(type) {
 	case *elastic5.Client:
 		allowed = false
 	case *elastic6.Client:
@@ -93,9 +97,9 @@ func testAccCheckElasticsearchOpenDistroRolesMappingDestroy(s *terraform.State) 
 		if err != nil {
 			return err
 		}
-		switch client := esClient.(type) {
+		switch esClient.(type) {
 		case *elastic7.Client:
-			_, err = resourceElasticsearchGetOpenDistroRolesMapping(rs.Primary.ID, client)
+			_, err = resourceElasticsearchGetOpenDistroRolesMapping(rs.Primary.ID, meta.(*ProviderConf))
 		default:
 		}
 
@@ -122,9 +126,9 @@ func testCheckElasticSearchOpenDistroRolesMappingExists(name string) resource.Te
 			if err != nil {
 				return err
 			}
-			switch client := esClient.(type) {
+			switch esClient.(type) {
 			case *elastic7.Client:
-				_, err = resourceElasticsearchGetOpenDistroRolesMapping(rs.Primary.ID, client)
+				_, err = resourceElasticsearchGetOpenDistroRolesMapping(rs.Primary.ID, meta.(*ProviderConf))
 			default:
 			}
 

--- a/es/resource_elasticsearch_opendistro_roles_mapping_test.go
+++ b/es/resource_elasticsearch_opendistro_roles_mapping_test.go
@@ -23,7 +23,11 @@ func TestAccElasticsearchOpenDistroRolesMapping(t *testing.T) {
 	}
 	meta := provider.Meta()
 	var allowed bool
-	switch meta.(type) {
+	esClient, err := getClient(meta.(*ProviderConf))
+	if err != nil {
+		t.Skipf("err: %s", err)
+	}
+	switch esClient.(type) {
 	case *elastic5.Client:
 		allowed = false
 	case *elastic6.Client:
@@ -89,7 +93,11 @@ func testAccCheckElasticsearchOpenDistroRolesMappingDestroy(s *terraform.State) 
 		meta := testAccOpendistroProvider.Meta()
 
 		var err error
-		switch client := meta.(type) {
+		esClient, err := getClient(meta.(*ProviderConf))
+		if err != nil {
+			return err
+		}
+		switch client := esClient.(type) {
 		case *elastic7.Client:
 			_, err = resourceElasticsearchGetOpenDistroRolesMapping(rs.Primary.ID, client)
 		default:
@@ -114,7 +122,11 @@ func testCheckElasticSearchOpenDistroRolesMappingExists(name string) resource.Te
 			meta := testAccOpendistroProvider.Meta()
 
 			var err error
-			switch client := meta.(type) {
+			esClient, err := getClient(meta.(*ProviderConf))
+			if err != nil {
+				return err
+			}
+			switch client := esClient.(type) {
 			case *elastic7.Client:
 				_, err = resourceElasticsearchGetOpenDistroRolesMapping(rs.Primary.ID, client)
 			default:

--- a/es/resource_elasticsearch_opendistro_roles_mapping_test.go
+++ b/es/resource_elasticsearch_opendistro_roles_mapping_test.go
@@ -23,11 +23,7 @@ func TestAccElasticsearchOpenDistroRolesMapping(t *testing.T) {
 	}
 	meta := provider.Meta()
 	var allowed bool
-	esClient, err := getClient(meta.(*ProviderConf))
-	if err != nil {
-		t.Skipf("err: %s", err)
-	}
-	switch esClient.(type) {
+	switch meta.(type) {
 	case *elastic5.Client:
 		allowed = false
 	case *elastic6.Client:

--- a/es/resource_elasticsearch_opendistro_user.go
+++ b/es/resource_elasticsearch_opendistro_user.go
@@ -108,7 +108,11 @@ func resourceElasticsearchOpenDistroUserDelete(d *schema.ResourceData, m interfa
 		return fmt.Errorf("Error building URL path for user: %+v", err)
 	}
 
-	switch client := m.(type) {
+	esClient, err := getClient(m.(*ProviderConf))
+	if err != nil {
+		return err
+	}
+	switch client := esClient.(type) {
 	case *elastic7.Client:
 		_, err = client.PerformRequest(context.TODO(), elastic7.PerformRequestOptions{
 			Method: "DELETE",
@@ -134,7 +138,11 @@ func resourceElasticsearchGetOpenDistroUser(userID string, m interface{}) (UserB
 	}
 
 	var body json.RawMessage
-	switch client := m.(type) {
+	esClient, err := getClient(m.(*ProviderConf))
+	if err != nil {
+		return *user, err
+	}
+	switch client := esClient.(type) {
 	case *elastic7.Client:
 		var res *elastic7.Response
 		res, err = client.PerformRequest(context.TODO(), elastic7.PerformRequestOptions{
@@ -184,7 +192,11 @@ func resourceElasticsearchPutOpenDistroUser(d *schema.ResourceData, m interface{
 	}
 
 	var body json.RawMessage
-	switch client := m.(type) {
+	esClient, err := getClient(m.(*ProviderConf))
+	if err != nil {
+		return nil, err
+	}
+	switch client := esClient.(type) {
 	case *elastic7.Client:
 		var res *elastic7.Response
 		res, err = client.PerformRequest(context.TODO(), elastic7.PerformRequestOptions{

--- a/es/resource_elasticsearch_opendistro_user_test.go
+++ b/es/resource_elasticsearch_opendistro_user_test.go
@@ -24,7 +24,11 @@ func TestAccElasticsearchOpenDistroUser(t *testing.T) {
 	}
 	meta := provider.Meta()
 	var allowed bool
-	switch meta.(type) {
+	esClient, err := getClient(meta.(*ProviderConf))
+	if err != nil {
+		t.Skipf("err: %s", err)
+	}
+	switch esClient.(type) {
 	case *elastic5.Client:
 		allowed = false
 	case *elastic6.Client:
@@ -118,7 +122,11 @@ func testAccCheckElasticsearchOpenDistroUserDestroy(s *terraform.State) error {
 		meta := testAccOpendistroProvider.Meta()
 
 		var err error
-		switch client := meta.(type) {
+		esClient, err := getClient(meta.(*ProviderConf))
+		if err != nil {
+			return err
+		}
+		switch client := esClient.(type) {
 		case *elastic7.Client:
 			_, err = resourceElasticsearchGetOpenDistroUser(rs.Primary.ID, client)
 		default:
@@ -144,7 +152,11 @@ func testCheckElasticSearchOpenDistroUserExists(name string) resource.TestCheckF
 			meta := testAccOpendistroProvider.Meta()
 
 			var err error
-			switch client := meta.(type) {
+			esClient, err := getClient(meta.(*ProviderConf))
+			if err != nil {
+				return err
+			}
+			switch client := esClient.(type) {
 			case *elastic7.Client:
 				_, err = resourceElasticsearchGetOpenDistroUser(rs.Primary.ID, client)
 			default:
@@ -173,7 +185,11 @@ func testCheckElasticSearchOpenDistroUserConnects(name string) resource.TestChec
 			meta := testAccOpendistroProvider.Meta()
 
 			var err error
-			switch meta.(type) {
+			esClient, err := getClient(meta.(*ProviderConf))
+			if err != nil {
+				return err
+			}
+			switch esClient.(type) {
 			case *elastic7.Client:
 				var client *elastic7.Client
 				client, err = elastic7.NewClient(

--- a/es/resource_elasticsearch_opendistro_user_test.go
+++ b/es/resource_elasticsearch_opendistro_user_test.go
@@ -23,8 +23,12 @@ func TestAccElasticsearchOpenDistroUser(t *testing.T) {
 		t.Skipf("err: %s", err)
 	}
 	meta := provider.Meta()
+	esClient, err := getClient(meta.(*ProviderConf))
+	if err != nil {
+		t.Skipf("err: %s", err)
+	}
 	var allowed bool
-	switch meta.(type) {
+	switch esClient.(type) {
 	case *elastic5.Client:
 		allowed = false
 	case *elastic6.Client:
@@ -122,9 +126,9 @@ func testAccCheckElasticsearchOpenDistroUserDestroy(s *terraform.State) error {
 		if err != nil {
 			return err
 		}
-		switch client := esClient.(type) {
+		switch esClient.(type) {
 		case *elastic7.Client:
-			_, err = resourceElasticsearchGetOpenDistroUser(rs.Primary.ID, client)
+			_, err = resourceElasticsearchGetOpenDistroUser(rs.Primary.ID, meta.(*ProviderConf))
 		default:
 		}
 
@@ -152,9 +156,9 @@ func testCheckElasticSearchOpenDistroUserExists(name string) resource.TestCheckF
 			if err != nil {
 				return err
 			}
-			switch client := esClient.(type) {
+			switch esClient.(type) {
 			case *elastic7.Client:
-				_, err = resourceElasticsearchGetOpenDistroUser(rs.Primary.ID, client)
+				_, err = resourceElasticsearchGetOpenDistroUser(rs.Primary.ID, meta.(*ProviderConf))
 			default:
 			}
 

--- a/es/resource_elasticsearch_opendistro_user_test.go
+++ b/es/resource_elasticsearch_opendistro_user_test.go
@@ -24,11 +24,7 @@ func TestAccElasticsearchOpenDistroUser(t *testing.T) {
 	}
 	meta := provider.Meta()
 	var allowed bool
-	esClient, err := getClient(meta.(*ProviderConf))
-	if err != nil {
-		t.Skipf("err: %s", err)
-	}
-	switch esClient.(type) {
+	switch meta.(type) {
 	case *elastic5.Client:
 		allowed = false
 	case *elastic6.Client:

--- a/es/resource_elasticsearch_snapshot_repository.go
+++ b/es/resource_elasticsearch_snapshot_repository.go
@@ -61,7 +61,7 @@ func resourceElasticsearchSnapshotRepositoryRead(d *schema.ResourceData, meta in
 	case *elastic6.Client:
 		repositoryType, settings, err = elastic6SnapshotGetRepository(client, id)
 	default:
-		elastic5Client := meta.(*elastic5.Client)
+		elastic5Client := client.(*elastic5.Client)
 		repositoryType, settings, err = elastic5SnapshotGetRepository(elastic5Client, id)
 	}
 
@@ -124,7 +124,7 @@ func resourceElasticsearchSnapshotRepositoryUpdate(d *schema.ResourceData, meta 
 	case *elastic6.Client:
 		err = elastic6SnapshotCreateRepository(client, name, repositoryType, settings)
 	default:
-		elastic5Client := meta.(*elastic5.Client)
+		elastic5Client := client.(*elastic5.Client)
 		err = elastic5SnapshotCreateRepository(elastic5Client, name, repositoryType, settings)
 	}
 
@@ -175,7 +175,7 @@ func resourceElasticsearchSnapshotRepositoryDelete(d *schema.ResourceData, meta 
 	case *elastic6.Client:
 		err = elastic6SnapshotDeleteRepository(client, id)
 	default:
-		elastic5Client := meta.(*elastic5.Client)
+		elastic5Client := client.(*elastic5.Client)
 		err = elastic5SnapshotDeleteRepository(elastic5Client, id)
 	}
 

--- a/es/resource_elasticsearch_snapshot_repository.go
+++ b/es/resource_elasticsearch_snapshot_repository.go
@@ -51,7 +51,11 @@ func resourceElasticsearchSnapshotRepositoryRead(d *schema.ResourceData, meta in
 	var repositoryType string
 	var settings map[string]interface{}
 	var err error
-	switch client := meta.(type) {
+	esClient, err := getClient(meta.(*ProviderConf))
+	if err != nil {
+		return err
+	}
+	switch client := esClient.(type) {
 	case *elastic7.Client:
 		repositoryType, settings, err = elastic7SnapshotGetRepository(client, id)
 	case *elastic6.Client:
@@ -110,7 +114,11 @@ func resourceElasticsearchSnapshotRepositoryUpdate(d *schema.ResourceData, meta 
 	}
 
 	var err error
-	switch client := meta.(type) {
+	esClient, err := getClient(meta.(*ProviderConf))
+	if err != nil {
+		return err
+	}
+	switch client := esClient.(type) {
 	case *elastic7.Client:
 		err = elastic7SnapshotCreateRepository(client, name, repositoryType, settings)
 	case *elastic6.Client:
@@ -157,7 +165,11 @@ func resourceElasticsearchSnapshotRepositoryDelete(d *schema.ResourceData, meta 
 	id := d.Id()
 
 	var err error
-	switch client := meta.(type) {
+	esClient, err := getClient(meta.(*ProviderConf))
+	if err != nil {
+		return err
+	}
+	switch client := esClient.(type) {
 	case *elastic7.Client:
 		err = elastic7SnapshotDeleteRepository(client, id)
 	case *elastic6.Client:

--- a/es/resource_elasticsearch_snapshot_repository_test.go
+++ b/es/resource_elasticsearch_snapshot_repository_test.go
@@ -60,7 +60,11 @@ func testCheckElasticsearchSnapshotRepositoryExists(name string) resource.TestCh
 		meta := testAccProvider.Meta()
 
 		var err error
-		switch client := meta.(type) {
+		esClient, err := getClient(meta.(*ProviderConf))
+		if err != nil {
+			return err
+		}
+		switch client := esClient.(type) {
 		case *elastic7.Client:
 			_, err = client.SnapshotGetRepository(rs.Primary.ID).Do(context.TODO())
 		case *elastic6.Client:
@@ -87,7 +91,11 @@ func testCheckElasticsearchSnapshotRepositoryDestroy(s *terraform.State) error {
 		meta := testAccProvider.Meta()
 
 		var err error
-		switch client := meta.(type) {
+		esClient, err := getClient(meta.(*ProviderConf))
+		if err != nil {
+			return err
+		}
+		switch client := esClient.(type) {
 		case *elastic7.Client:
 			_, err = client.SnapshotGetRepository(rs.Primary.ID).Do(context.TODO())
 		case *elastic6.Client:

--- a/es/resource_elasticsearch_snapshot_repository_test.go
+++ b/es/resource_elasticsearch_snapshot_repository_test.go
@@ -70,7 +70,7 @@ func testCheckElasticsearchSnapshotRepositoryExists(name string) resource.TestCh
 		case *elastic6.Client:
 			_, err = client.SnapshotGetRepository(rs.Primary.ID).Do(context.TODO())
 		default:
-			elastic5Client := meta.(*elastic5.Client)
+			elastic5Client := client.(*elastic5.Client)
 			_, err = elastic5Client.SnapshotGetRepository(rs.Primary.ID).Do(context.TODO())
 		}
 
@@ -101,7 +101,7 @@ func testCheckElasticsearchSnapshotRepositoryDestroy(s *terraform.State) error {
 		case *elastic6.Client:
 			_, err = client.SnapshotGetRepository(rs.Primary.ID).Do(context.TODO())
 		default:
-			elastic5Client := meta.(*elastic5.Client)
+			elastic5Client := client.(*elastic5.Client)
 			_, err = elastic5Client.SnapshotGetRepository(rs.Primary.ID).Do(context.TODO())
 		}
 

--- a/es/resource_elasticsearch_xpack_index_lifecycle_policy.go
+++ b/es/resource_elasticsearch_xpack_index_lifecycle_policy.go
@@ -66,7 +66,11 @@ func resourceElasticsearchXpackIndexLifecyclePolicyRead(d *schema.ResourceData, 
 
 	var result string
 	var err error
-	switch client := meta.(type) {
+	esClient, err := getClient(meta.(*ProviderConf))
+	if err != nil {
+		return err
+	}
+	switch client := esClient.(type) {
 	case *elastic7.Client:
 		result, err = elastic7IndexGetLifecyclePolicy(client, id)
 	case *elastic6.Client:
@@ -120,7 +124,11 @@ func resourceElasticsearchXpackIndexLifecyclePolicyDelete(d *schema.ResourceData
 	id := d.Id()
 
 	var err error
-	switch client := meta.(type) {
+	esClient, err := getClient(meta.(*ProviderConf))
+	if err != nil {
+		return err
+	}
+	switch client := esClient.(type) {
 	case *elastic7.Client:
 		err = elastic7IndexDeleteLifecyclePolicy(client, id)
 	case *elastic6.Client:
@@ -151,7 +159,11 @@ func resourceElasticsearchPutIndexLifecyclePolicy(d *schema.ResourceData, meta i
 	body := d.Get("body").(string)
 
 	var err error
-	switch client := meta.(type) {
+	esClient, err := getClient(meta.(*ProviderConf))
+	if err != nil {
+		return err
+	}
+	switch client := esClient.(type) {
 	case *elastic7.Client:
 		err = elastic7IndexPutLifecyclePolicy(client, name, body)
 	case *elastic6.Client:

--- a/es/resource_elasticsearch_xpack_index_lifecycle_policy_test.go
+++ b/es/resource_elasticsearch_xpack_index_lifecycle_policy_test.go
@@ -23,7 +23,11 @@ func TestAccElasticsearchXpackIndexLifecyclePolicy(t *testing.T) {
 	}
 	meta := provider.Meta()
 	var allowed bool
-	switch meta.(type) {
+	esClient, err := getClient(meta.(*ProviderConf))
+	if err != nil {
+		t.Skipf("err: %s", err)
+	}
+	switch esClient.(type) {
 	case *elastic5.Client:
 		allowed = false
 	default:
@@ -58,7 +62,11 @@ func TestAccElasticsearchXpackIndexLifecyclePolicy_importBasic(t *testing.T) {
 	}
 	meta := provider.Meta()
 	var allowed bool
-	switch meta.(type) {
+	esClient, err := getClient(meta.(*ProviderConf))
+	if err != nil {
+		t.Skipf("err: %s", err)
+	}
+	switch esClient.(type) {
 	case *elastic5.Client:
 		allowed = false
 	default:
@@ -100,7 +108,11 @@ func testCheckElasticsearchXpackIndexLifecyclePolicyExists(name string) resource
 		meta := testAccXPackProvider.Meta()
 
 		var err error
-		switch client := meta.(type) {
+		esClient, err := getClient(meta.(*ProviderConf))
+		if err != nil {
+			return err
+		}
+		switch client := esClient.(type) {
 		case *elastic7.Client:
 			_, err = client.XPackIlmGetLifecycle().Policy(rs.Primary.ID).Do(context.TODO())
 		case *elastic6.Client:
@@ -126,7 +138,11 @@ func testCheckElasticsearchXpackIndexLifecyclePolicyDestroy(s *terraform.State) 
 		meta := testAccXPackProvider.Meta()
 
 		var err error
-		switch client := meta.(type) {
+		esClient, err := getClient(meta.(*ProviderConf))
+		if err != nil {
+			return err
+		}
+		switch client := esClient.(type) {
 		case *elastic7.Client:
 			_, err = client.XPackIlmGetLifecycle().Policy(rs.Primary.ID).Do(context.TODO())
 		case *elastic6.Client:

--- a/es/resource_elasticsearch_xpack_index_lifecycle_policy_test.go
+++ b/es/resource_elasticsearch_xpack_index_lifecycle_policy_test.go
@@ -22,8 +22,12 @@ func TestAccElasticsearchXpackIndexLifecyclePolicy(t *testing.T) {
 		t.Skipf("err: %s", err)
 	}
 	meta := provider.Meta()
+	esClient, err := getClient(meta.(*ProviderConf))
+	if err != nil {
+		t.Skipf("err: %s", err)
+	}
 	var allowed bool
-	switch meta.(type) {
+	switch esClient.(type) {
 	case *elastic5.Client:
 		allowed = false
 	default:
@@ -57,8 +61,12 @@ func TestAccElasticsearchXpackIndexLifecyclePolicy_importBasic(t *testing.T) {
 		t.Skipf("err: %s", err)
 	}
 	meta := provider.Meta()
+	esClient, err := getClient(meta.(*ProviderConf))
+	if err != nil {
+		t.Skipf("err: %s", err)
+	}
 	var allowed bool
-	switch meta.(type) {
+	switch esClient.(type) {
 	case *elastic5.Client:
 		allowed = false
 	default:

--- a/es/resource_elasticsearch_xpack_index_lifecycle_policy_test.go
+++ b/es/resource_elasticsearch_xpack_index_lifecycle_policy_test.go
@@ -23,11 +23,7 @@ func TestAccElasticsearchXpackIndexLifecyclePolicy(t *testing.T) {
 	}
 	meta := provider.Meta()
 	var allowed bool
-	esClient, err := getClient(meta.(*ProviderConf))
-	if err != nil {
-		t.Skipf("err: %s", err)
-	}
-	switch esClient.(type) {
+	switch meta.(type) {
 	case *elastic5.Client:
 		allowed = false
 	default:
@@ -62,11 +58,7 @@ func TestAccElasticsearchXpackIndexLifecyclePolicy_importBasic(t *testing.T) {
 	}
 	meta := provider.Meta()
 	var allowed bool
-	esClient, err := getClient(meta.(*ProviderConf))
-	if err != nil {
-		t.Skipf("err: %s", err)
-	}
-	switch esClient.(type) {
+	switch meta.(type) {
 	case *elastic5.Client:
 		allowed = false
 	default:

--- a/es/resource_elasticsearch_xpack_license.go
+++ b/es/resource_elasticsearch_xpack_license.go
@@ -75,7 +75,11 @@ func resourceElasticsearchLicenseRead(d *schema.ResourceData, meta interface{}) 
 func resourceElasticsearchLicenseDelete(d *schema.ResourceData, meta interface{}) error {
 	var err error
 
-	switch client := meta.(type) {
+	esClient, err := getClient(meta.(*ProviderConf))
+	if err != nil {
+		return err
+	}
+	switch client := esClient.(type) {
 	case *elastic7.Client:
 		_, err = client.PerformRequest(context.TODO(), elastic7.PerformRequestOptions{
 			Method: "DELETE",
@@ -103,7 +107,11 @@ func resourceElasticsearchGetXpackLicense(meta interface{}) (License, error) {
 	var body json.RawMessage
 	var err error
 
-	switch client := meta.(type) {
+	esClient, err := getClient(meta.(*ProviderConf))
+	if err != nil {
+		return *license, err
+	}
+	switch client := esClient.(type) {
 	case *elastic7.Client:
 		var res *elastic7.Response
 		res, err = client.PerformRequest(context.TODO(), elastic7.PerformRequestOptions{
@@ -161,7 +169,11 @@ func resourceElasticsearchPutEnterpriseLicense(l string, meta interface{}) (Lice
 	var emptyLicense License
 	var body json.RawMessage
 	var err error
-	switch client := meta.(type) {
+	esClient, err := getClient(meta.(*ProviderConf))
+	if err != nil {
+		return emptyLicense, err
+	}
+	switch client := esClient.(type) {
 	case *elastic7.Client:
 		var res *elastic7.Response
 		res, err = client.PerformRequest(context.TODO(), elastic7.PerformRequestOptions{
@@ -197,7 +209,11 @@ func resourceElasticsearchPutEnterpriseLicense(l string, meta interface{}) (Lice
 func resourceElasticsearchPostBasicLicense(meta interface{}) (License, error) {
 	var l License
 	var err error
-	switch client := meta.(type) {
+	esClient, err := getClient(meta.(*ProviderConf))
+	if err != nil {
+		return l, err
+	}
+	switch client := esClient.(type) {
 	case *elastic7.Client:
 		_, err = client.PerformRequest(context.TODO(), elastic7.PerformRequestOptions{
 			Method: "POST",

--- a/es/resource_elasticsearch_xpack_license_test.go
+++ b/es/resource_elasticsearch_xpack_license_test.go
@@ -26,8 +26,12 @@ func TestAccElasticsearchLicense_Basic(t *testing.T) {
 		t.Skipf("err: %s", err)
 	}
 	meta := provider.Meta()
+	esClient, err := getClient(meta.(*ProviderConf))
+	if err != nil {
+		t.Skipf("err: %s", err)
+	}
 	var allowed bool
-	switch meta.(type) {
+	switch esClient.(type) {
 	case *elastic5.Client:
 		allowed = false
 	default:

--- a/es/resource_elasticsearch_xpack_license_test.go
+++ b/es/resource_elasticsearch_xpack_license_test.go
@@ -27,7 +27,11 @@ func TestAccElasticsearchLicense_Basic(t *testing.T) {
 	}
 	meta := provider.Meta()
 	var allowed bool
-	switch meta.(type) {
+	esClient, err := getClient(meta.(*ProviderConf))
+	if err != nil {
+		t.Skipf("err: %s", err)
+	}
+	switch esClient.(type) {
 	case *elastic5.Client:
 		allowed = false
 	default:
@@ -81,7 +85,11 @@ func testCheckElasticsearchLicenseExists(name string) resource.TestCheckFunc {
 		meta := testAccXPackProvider.Meta()
 
 		var err error
-		switch client := meta.(type) {
+		esClient, err := getClient(meta.(*ProviderConf))
+		if err != nil {
+			return err
+		}
+		switch client := esClient.(type) {
 		case *elastic7.Client:
 			var resp *elastic7.XPackInfoServiceResponse
 			resp, err = client.XPackInfo().Do(context.TODO())
@@ -111,7 +119,11 @@ func testCheckElasticsearchLicenseDestroy(s *terraform.State) error {
 		meta := testAccXPackProvider.Meta()
 
 		var err error
-		switch client := meta.(type) {
+		esClient, err := getClient(meta.(*ProviderConf))
+		if err != nil {
+			return err
+		}
+		switch client := esClient.(type) {
 		case *elastic7.Client:
 			var resp *elastic7.XPackInfoServiceResponse
 			resp, err = client.XPackInfo().Do(context.TODO())

--- a/es/resource_elasticsearch_xpack_license_test.go
+++ b/es/resource_elasticsearch_xpack_license_test.go
@@ -27,11 +27,7 @@ func TestAccElasticsearchLicense_Basic(t *testing.T) {
 	}
 	meta := provider.Meta()
 	var allowed bool
-	esClient, err := getClient(meta.(*ProviderConf))
-	if err != nil {
-		t.Skipf("err: %s", err)
-	}
-	switch esClient.(type) {
+	switch meta.(type) {
 	case *elastic5.Client:
 		allowed = false
 	default:

--- a/es/resource_elasticsearch_xpack_role.go
+++ b/es/resource_elasticsearch_xpack_role.go
@@ -301,39 +301,51 @@ func buildPutRoleBody(d *schema.ResourceData, m interface{}) (string, error) {
 }
 
 func xpackPutRole(d *schema.ResourceData, m interface{}, name string, body string) error {
-	if client, ok := m.(*elastic7.Client); ok {
+	esClient, err := getClient(m.(*ProviderConf))
+	if err != nil {
+		return err
+	}
+	if client, ok := esClient.(*elastic7.Client); ok {
 		return elastic7PutRole(client, name, body)
 	}
-	if client, ok := m.(*elastic6.Client); ok {
+	if client, ok := esClient.(*elastic6.Client); ok {
 		return elastic6PutRole(client, name, body)
 	}
-	if client, ok := m.(*elastic5.Client); ok {
+	if client, ok := esClient.(*elastic5.Client); ok {
 		return elastic5PutRole(client, name, body)
 	}
 	return errors.New("unhandled client type")
 }
 
 func xpackGetRole(d *schema.ResourceData, m interface{}, name string) (XPackSecurityRole, error) {
-	if client, ok := m.(*elastic7.Client); ok {
+	esClient, err := getClient(m.(*ProviderConf))
+	if err != nil {
+		return XPackSecurityRole{}, err
+	}
+	if client, ok := esClient.(*elastic7.Client); ok {
 		return elastic7GetRole(client, name)
 	}
-	if client, ok := m.(*elastic6.Client); ok {
+	if client, ok := esClient.(*elastic6.Client); ok {
 		return elastic6GetRole(client, name)
 	}
-	if client, ok := m.(*elastic5.Client); ok {
+	if client, ok := esClient.(*elastic5.Client); ok {
 		return elastic5GetRole(client, name)
 	}
 	return XPackSecurityRole{}, errors.New("unhandled client type")
 }
 
 func xpackDeleteRole(d *schema.ResourceData, m interface{}, name string) error {
-	if client, ok := m.(*elastic7.Client); ok {
+	esClient, err := getClient(m.(*ProviderConf))
+	if err != nil {
+		return err
+	}
+	if client, ok := esClient.(*elastic7.Client); ok {
 		return elastic7DeleteRole(client, name)
 	}
-	if client, ok := m.(*elastic6.Client); ok {
+	if client, ok := esClient.(*elastic6.Client); ok {
 		return elastic6DeleteRole(client, name)
 	}
-	if client, ok := m.(*elastic5.Client); ok {
+	if client, ok := esClient.(*elastic5.Client); ok {
 		return elastic5DeleteRole(client, name)
 	}
 	return errors.New("unhandled client type")

--- a/es/resource_elasticsearch_xpack_role_mapping.go
+++ b/es/resource_elasticsearch_xpack_role_mapping.go
@@ -162,39 +162,51 @@ func buildPutRoleMappingBody(d *schema.ResourceData, m interface{}) (string, err
 }
 
 func xpackPutRoleMapping(d *schema.ResourceData, m interface{}, name string, body string) error {
-	if client, ok := m.(*elastic7.Client); ok {
+	esClient, err := getClient(m.(*ProviderConf))
+	if err != nil {
+		return err
+	}
+	if client, ok := esClient.(*elastic7.Client); ok {
 		return elastic7PutRoleMapping(client, name, body)
 	}
-	if client, ok := m.(*elastic6.Client); ok {
+	if client, ok := esClient.(*elastic6.Client); ok {
 		return elastic6PutRoleMapping(client, name, body)
 	}
-	if client, ok := m.(*elastic5.Client); ok {
+	if client, ok := esClient.(*elastic5.Client); ok {
 		return elastic5PutRoleMapping(client, name, body)
 	}
 	return errors.New("unhandled client type")
 }
 
 func xpackGetRoleMapping(d *schema.ResourceData, m interface{}, name string) (XPackSecurityRoleMapping, error) {
-	if client, ok := m.(*elastic7.Client); ok {
+	esClient, err := getClient(m.(*ProviderConf))
+	if err != nil {
+		return XPackSecurityRoleMapping{}, err
+	}
+	if client, ok := esClient.(*elastic7.Client); ok {
 		return elastic7GetRoleMapping(client, name)
 	}
-	if client, ok := m.(*elastic6.Client); ok {
+	if client, ok := esClient.(*elastic6.Client); ok {
 		return elastic6GetRoleMapping(client, name)
 	}
-	if client, ok := m.(*elastic5.Client); ok {
+	if client, ok := esClient.(*elastic5.Client); ok {
 		return elastic5GetRoleMapping(client, name)
 	}
 	return XPackSecurityRoleMapping{}, errors.New("unhandled client type")
 }
 
 func xpackDeleteRoleMapping(d *schema.ResourceData, m interface{}, name string) error {
-	if client, ok := m.(*elastic7.Client); ok {
+	esClient, err := getClient(m.(*ProviderConf))
+	if err != nil {
+		return err
+	}
+	if client, ok := esClient.(*elastic7.Client); ok {
 		return elastic7DeleteRoleMapping(client, name)
 	}
-	if client, ok := m.(*elastic6.Client); ok {
+	if client, ok := esClient.(*elastic6.Client); ok {
 		return elastic6DeleteRoleMapping(client, name)
 	}
-	if client, ok := m.(*elastic5.Client); ok {
+	if client, ok := esClient.(*elastic5.Client); ok {
 		return elastic5DeleteRoleMapping(client, name)
 	}
 	return errors.New("unhandled client type")

--- a/es/resource_elasticsearch_xpack_role_mapping_test.go
+++ b/es/resource_elasticsearch_xpack_role_mapping_test.go
@@ -23,8 +23,12 @@ func TestAccElasticsearchXpackRoleMapping(t *testing.T) {
 		t.Skipf("err: %s", err)
 	}
 	meta := provider.Meta()
+	esClient, err := getClient(meta.(*ProviderConf))
+	if err != nil {
+		t.Skipf("err: %s", err)
+	}
 	var allowed bool
-	switch meta.(type) {
+	switch esClient.(type) {
 	case *elastic5.Client:
 		allowed = false
 	default:
@@ -232,8 +236,12 @@ func TestAccRoleMappingResource_importBasic(t *testing.T) {
 		t.Skipf("err: %s", err)
 	}
 	meta := provider.Meta()
+	esClient, err := getClient(meta.(*ProviderConf))
+	if err != nil {
+		t.Skipf("err: %s", err)
+	}
 	var allowed bool
-	switch meta.(type) {
+	switch esClient.(type) {
 	case *elastic5.Client:
 		allowed = false
 	default:

--- a/es/resource_elasticsearch_xpack_role_mapping_test.go
+++ b/es/resource_elasticsearch_xpack_role_mapping_test.go
@@ -24,7 +24,11 @@ func TestAccElasticsearchXpackRoleMapping(t *testing.T) {
 	}
 	meta := provider.Meta()
 	var allowed bool
-	switch meta.(type) {
+	esClient, err := getClient(meta.(*ProviderConf))
+	if err != nil {
+		t.Skipf("err: %s", err)
+	}
+	switch esClient.(type) {
 	case *elastic5.Client:
 		allowed = false
 	default:
@@ -225,7 +229,11 @@ func TestAccRoleMappingResource_importBasic(t *testing.T) {
 	}
 	meta := provider.Meta()
 	var allowed bool
-	switch meta.(type) {
+	esClient, err := getClient(meta.(*ProviderConf))
+	if err != nil {
+		t.Skipf("err: %s", err)
+	}
+	switch esClient.(type) {
 	case *elastic5.Client:
 		allowed = false
 	default:

--- a/es/resource_elasticsearch_xpack_role_test.go
+++ b/es/resource_elasticsearch_xpack_role_test.go
@@ -23,8 +23,12 @@ func TestAccElasticsearchXpackRole(t *testing.T) {
 		t.Skipf("err: %s", err)
 	}
 	meta := provider.Meta()
+	esClient, err := getClient(meta.(*ProviderConf))
+	if err != nil {
+		t.Skipf("err: %s", err)
+	}
 	var allowed bool
-	switch meta.(type) {
+	switch esClient.(type) {
 	case *elastic5.Client:
 		allowed = false
 	default:
@@ -284,8 +288,12 @@ func TestAccRoleResource_importBasic(t *testing.T) {
 		t.Skipf("err: %s", err)
 	}
 	meta := provider.Meta()
+	esClient, err := getClient(meta.(*ProviderConf))
+	if err != nil {
+		t.Skipf("err: %s", err)
+	}
 	var allowed bool
-	switch meta.(type) {
+	switch esClient.(type) {
 	case *elastic5.Client:
 		allowed = false
 	default:

--- a/es/resource_elasticsearch_xpack_role_test.go
+++ b/es/resource_elasticsearch_xpack_role_test.go
@@ -24,7 +24,11 @@ func TestAccElasticsearchXpackRole(t *testing.T) {
 	}
 	meta := provider.Meta()
 	var allowed bool
-	switch meta.(type) {
+	esClient, err := getClient(meta.(*ProviderConf))
+	if err != nil {
+		t.Skipf("err: %s", err)
+	}
+	switch esClient.(type) {
 	case *elastic5.Client:
 		allowed = false
 	default:
@@ -279,7 +283,11 @@ func TestAccRoleResource_importBasic(t *testing.T) {
 	}
 	meta := provider.Meta()
 	var allowed bool
-	switch meta.(type) {
+	esClient, err := getClient(meta.(*ProviderConf))
+	if err != nil {
+		t.Skipf("err: %s", err)
+	}
+	switch esClient.(type) {
 	case *elastic5.Client:
 		allowed = false
 	default:

--- a/es/resource_elasticsearch_xpack_role_test.go
+++ b/es/resource_elasticsearch_xpack_role_test.go
@@ -24,11 +24,7 @@ func TestAccElasticsearchXpackRole(t *testing.T) {
 	}
 	meta := provider.Meta()
 	var allowed bool
-	esClient, err := getClient(meta.(*ProviderConf))
-	if err != nil {
-		t.Skipf("err: %s", err)
-	}
-	switch esClient.(type) {
+	switch meta.(type) {
 	case *elastic5.Client:
 		allowed = false
 	default:
@@ -100,8 +96,11 @@ func testAccCheckRoleDestroy(s *terraform.State) error {
 			continue
 		}
 		meta := testAccXPackProvider.Meta()
-
-		if client, ok := meta.(*elastic7.Client); ok {
+		esClient, err := getClient(meta.(*ProviderConf))
+		if err != nil {
+			return err
+		}
+		if client, ok := esClient.(*elastic7.Client); ok {
 			if _, err := client.XPackSecurityGetRole(rs.Primary.ID).Do(context.TODO()); err != nil {
 				if elasticErr, ok := err.(*elastic7.Error); ok && elasticErr.Status == 404 {
 					return nil
@@ -112,7 +111,7 @@ func testAccCheckRoleDestroy(s *terraform.State) error {
 				return err
 			}
 
-		} else if client, ok := meta.(*elastic6.Client); ok {
+		} else if client, ok := esClient.(*elastic6.Client); ok {
 			if _, err := client.XPackSecurityGetRole(rs.Primary.ID).Do(context.TODO()); err != nil {
 				if elasticErr, ok := err.(*elastic6.Error); ok && elasticErr.Status == 404 {
 					return nil
@@ -138,14 +137,17 @@ func testCheckRoleExists(name string) resource.TestCheckFunc {
 		if rs.Primary.ID == "" {
 			return fmt.Errorf("No role mapping ID is set")
 		}
-
-		meta := testAccXPackProvider.Meta()
-
 		var err error
-		if client, ok := meta.(*elastic7.Client); ok {
+		meta := testAccXPackProvider.Meta()
+		esClient, err := getClient(meta.(*ProviderConf))
+		if err != nil {
+			return err
+		}
+
+		if client, ok := esClient.(*elastic7.Client); ok {
 			_, err = client.XPackSecurityGetRole(rs.Primary.ID).Do(context.TODO())
 		} else {
-			client := meta.(*elastic6.Client)
+			client := esClient.(*elastic6.Client)
 			_, err = client.XPackSecurityGetRole(rs.Primary.ID).Do(context.TODO())
 		}
 
@@ -283,11 +285,7 @@ func TestAccRoleResource_importBasic(t *testing.T) {
 	}
 	meta := provider.Meta()
 	var allowed bool
-	esClient, err := getClient(meta.(*ProviderConf))
-	if err != nil {
-		t.Skipf("err: %s", err)
-	}
-	switch esClient.(type) {
+	switch meta.(type) {
 	case *elastic5.Client:
 		allowed = false
 	default:

--- a/es/resource_elasticsearch_xpack_snapshot_lifecycle_policy.go
+++ b/es/resource_elasticsearch_xpack_snapshot_lifecycle_policy.go
@@ -50,7 +50,11 @@ func resourceElasticsearchXpackSnapshotLifecyclePolicyRead(d *schema.ResourceDat
 
 	var result string
 	var err error
-	switch client := meta.(type) {
+	esClient, err := getClient(meta.(*ProviderConf))
+	if err != nil {
+		return err
+	}
+	switch client := esClient.(type) {
 	case *elastic7.Client:
 		result, err = elastic7SnapshotGetLifecyclePolicy(client, id)
 	default:
@@ -114,7 +118,11 @@ func resourceElasticsearchXpackSnapshotLifecyclePolicyDelete(d *schema.ResourceD
 	id := d.Id()
 
 	var err error
-	switch client := meta.(type) {
+	esClient, err := getClient(meta.(*ProviderConf))
+	if err != nil {
+		return err
+	}
+	switch client := esClient.(type) {
 	case *elastic7.Client:
 		err = elastic7SnapshotDeleteLifecyclePolicy(client, id)
 	default:
@@ -141,7 +149,11 @@ func resourceElasticsearchPutSnapshotLifecyclePolicy(d *schema.ResourceData, met
 	body := d.Get("body").(string)
 
 	var err error
-	switch client := meta.(type) {
+	esClient, err := getClient(meta.(*ProviderConf))
+	if err != nil {
+		return err
+	}
+	switch client := esClient.(type) {
 	case *elastic7.Client:
 		err = elastic7SnapshotPutLifecyclePolicy(client, name, body)
 	default:

--- a/es/resource_elasticsearch_xpack_snapshot_lifecycle_policy_test.go
+++ b/es/resource_elasticsearch_xpack_snapshot_lifecycle_policy_test.go
@@ -24,11 +24,7 @@ func TestAccElasticsearchXpackSnapshotLifecyclePolicy(t *testing.T) {
 	}
 	meta := provider.Meta()
 	var allowed bool
-	esClient, err := getClient(meta.(*ProviderConf))
-	if err != nil {
-		t.Skipf("err: %s", err)
-	}
-	switch esClient.(type) {
+	switch meta.(type) {
 	case *elastic5.Client, *elastic6.Client:
 		allowed = false
 	default:
@@ -66,11 +62,7 @@ func TestAccElasticsearchXpackSnapshotLifecyclePolicy_importBasic(t *testing.T) 
 	}
 	meta := provider.Meta()
 	var allowed bool
-	esClient, err := getClient(meta.(*ProviderConf))
-	if err != nil {
-		t.Skipf("err: %s", err)
-	}
-	switch esClient.(type) {
+	switch meta.(type) {
 	case *elastic5.Client, *elastic6.Client:
 		allowed = false
 	default:

--- a/es/resource_elasticsearch_xpack_snapshot_lifecycle_policy_test.go
+++ b/es/resource_elasticsearch_xpack_snapshot_lifecycle_policy_test.go
@@ -23,8 +23,12 @@ func TestAccElasticsearchXpackSnapshotLifecyclePolicy(t *testing.T) {
 		t.Skipf("err: %s", err)
 	}
 	meta := provider.Meta()
+	esClient, err := getClient(meta.(*ProviderConf))
+	if err != nil {
+		t.Skipf("err: %s", err)
+	}
 	var allowed bool
-	switch meta.(type) {
+	switch esClient.(type) {
 	case *elastic5.Client, *elastic6.Client:
 		allowed = false
 	default:
@@ -62,7 +66,11 @@ func TestAccElasticsearchXpackSnapshotLifecyclePolicy_importBasic(t *testing.T) 
 	}
 	meta := provider.Meta()
 	var allowed bool
-	switch meta.(type) {
+	esClient, err := getClient(meta.(*ProviderConf))
+	if err != nil {
+		t.Skipf("err: %s", err)
+	}
+	switch esClient.(type) {
 	case *elastic5.Client, *elastic6.Client:
 		allowed = false
 	default:

--- a/es/resource_elasticsearch_xpack_snapshot_lifecycle_policy_test.go
+++ b/es/resource_elasticsearch_xpack_snapshot_lifecycle_policy_test.go
@@ -24,7 +24,11 @@ func TestAccElasticsearchXpackSnapshotLifecyclePolicy(t *testing.T) {
 	}
 	meta := provider.Meta()
 	var allowed bool
-	switch meta.(type) {
+	esClient, err := getClient(meta.(*ProviderConf))
+	if err != nil {
+		t.Skipf("err: %s", err)
+	}
+	switch esClient.(type) {
 	case *elastic5.Client, *elastic6.Client:
 		allowed = false
 	default:
@@ -62,7 +66,11 @@ func TestAccElasticsearchXpackSnapshotLifecyclePolicy_importBasic(t *testing.T) 
 	}
 	meta := provider.Meta()
 	var allowed bool
-	switch meta.(type) {
+	esClient, err := getClient(meta.(*ProviderConf))
+	if err != nil {
+		t.Skipf("err: %s", err)
+	}
+	switch esClient.(type) {
 	case *elastic5.Client, *elastic6.Client:
 		allowed = false
 	default:
@@ -107,7 +115,11 @@ func testCheckElasticsearchXpackSnapshotLifecyclePolicyExists(name string) resou
 		meta := testAccXPackProvider.Meta()
 
 		var err error
-		switch client := meta.(type) {
+		esClient, err := getClient(meta.(*ProviderConf))
+		if err != nil {
+			return err
+		}
+		switch client := esClient.(type) {
 		case *elastic7.Client:
 			_, err = client.PerformRequest(context.TODO(), elastic7.PerformRequestOptions{Method: http.MethodGet, Path: "/_slm/policy/" + rs.Primary.ID})
 		default:
@@ -131,7 +143,11 @@ func testCheckElasticsearchXpackSnapshotLifecyclePolicyDestroy(s *terraform.Stat
 		meta := testAccXPackProvider.Meta()
 
 		var err error
-		switch client := meta.(type) {
+		esClient, err := getClient(meta.(*ProviderConf))
+		if err != nil {
+			return err
+		}
+		switch client := esClient.(type) {
 		case *elastic7.Client:
 			_, err = client.PerformRequest(context.TODO(), elastic7.PerformRequestOptions{Method: http.MethodDelete, Path: "/_slm/policy/" + rs.Primary.ID})
 		default:

--- a/es/resource_elasticsearch_xpack_user.go
+++ b/es/resource_elasticsearch_xpack_user.go
@@ -200,39 +200,51 @@ func buildPutUserBody(d *schema.ResourceData, m interface{}) (string, error) {
 }
 
 func xpackPutUser(d *schema.ResourceData, m interface{}, name string, body string) error {
-	if client, ok := m.(*elastic7.Client); ok {
+	esClient, err := getClient(m.(*ProviderConf))
+	if err != nil {
+		return err
+	}
+	if client, ok := esClient.(*elastic7.Client); ok {
 		return elastic7PutUser(client, name, body)
 	}
-	if client, ok := m.(*elastic6.Client); ok {
+	if client, ok := esClient.(*elastic6.Client); ok {
 		return elastic6PutUser(client, name, body)
 	}
-	if client, ok := m.(*elastic5.Client); ok {
+	if client, ok := esClient.(*elastic5.Client); ok {
 		return elastic5PutUser(client, name, body)
 	}
 	return errors.New("unhandled client type")
 }
 
 func xpackGetUser(d *schema.ResourceData, m interface{}, name string) (XPackSecurityUser, error) {
-	if client, ok := m.(*elastic7.Client); ok {
+	esClient, err := getClient(m.(*ProviderConf))
+	if err != nil {
+		return XPackSecurityUser{}, err
+	}
+	if client, ok := esClient.(*elastic7.Client); ok {
 		return elastic7GetUser(client, name)
 	}
-	if client, ok := m.(*elastic6.Client); ok {
+	if client, ok := esClient.(*elastic6.Client); ok {
 		return elastic6GetUser(client, name)
 	}
-	if client, ok := m.(*elastic5.Client); ok {
+	if client, ok := esClient.(*elastic5.Client); ok {
 		return elastic5GetUser(client, name)
 	}
 	return XPackSecurityUser{}, errors.New("unhandled client type")
 }
 
 func xpackDeleteUser(d *schema.ResourceData, m interface{}, name string) error {
-	if client, ok := m.(*elastic7.Client); ok {
+	esClient, err := getClient(m.(*ProviderConf))
+	if err != nil {
+		return err
+	}
+	if client, ok := esClient.(*elastic7.Client); ok {
 		return elastic7DeleteUser(client, name)
 	}
-	if client, ok := m.(*elastic6.Client); ok {
+	if client, ok := esClient.(*elastic6.Client); ok {
 		return elastic6DeleteUser(client, name)
 	}
-	if client, ok := m.(*elastic5.Client); ok {
+	if client, ok := esClient.(*elastic5.Client); ok {
 		return elastic5DeleteUser(client, name)
 	}
 	return errors.New("unhandled client type")

--- a/es/resource_elasticsearch_xpack_user_test.go
+++ b/es/resource_elasticsearch_xpack_user_test.go
@@ -23,7 +23,11 @@ func TestAccElasticsearchXpackUser(t *testing.T) {
 	}
 	meta := provider.Meta()
 	var allowed bool
-	switch meta.(type) {
+	esClient, err := getClient(meta.(*ProviderConf))
+	if err != nil {
+		t.Skipf("err: %s", err)
+	}
+	switch esClient.(type) {
 	case *elastic5.Client:
 		allowed = false
 	case *elastic6.Client:
@@ -188,7 +192,11 @@ func TestAccUserResource_importBasic(t *testing.T) {
 	}
 	meta := provider.Meta()
 	var allowed bool
-	switch meta.(type) {
+	esClient, err := getClient(meta.(*ProviderConf))
+	if err != nil {
+		t.Skipf("err: %s", err)
+	}
+	switch esClient.(type) {
 	case *elastic5.Client:
 		allowed = false
 	case *elastic6.Client:

--- a/es/resource_elasticsearch_xpack_user_test.go
+++ b/es/resource_elasticsearch_xpack_user_test.go
@@ -22,8 +22,12 @@ func TestAccElasticsearchXpackUser(t *testing.T) {
 		t.Skipf("err: %s", err)
 	}
 	meta := provider.Meta()
+	esClient, err := getClient(meta.(*ProviderConf))
+	if err != nil {
+		t.Skipf("err: %s", err)
+	}
 	var allowed bool
-	switch meta.(type) {
+	switch esClient.(type) {
 	case *elastic5.Client:
 		allowed = false
 	case *elastic6.Client:
@@ -194,8 +198,12 @@ func TestAccUserResource_importBasic(t *testing.T) {
 		t.Skipf("err: %s", err)
 	}
 	meta := provider.Meta()
+	esClient, err := getClient(meta.(*ProviderConf))
+	if err != nil {
+		t.Skipf("err: %s", err)
+	}
 	var allowed bool
-	switch meta.(type) {
+	switch esClient.(type) {
 	case *elastic5.Client:
 		allowed = false
 	case *elastic6.Client:

--- a/es/resource_elasticsearch_xpack_watch.go
+++ b/es/resource_elasticsearch_xpack_watch.go
@@ -100,7 +100,12 @@ func resourceElasticsearchWatchRead(d *schema.ResourceData, m interface{}) error
 	}
 
 	var watch []byte
-	switch m.(type) {
+
+	esClient, err := getClient(m.(*ProviderConf))
+	if err != nil {
+		return err
+	}
+	switch esClient.(type) {
 	case *elastic7.Client:
 		watchResponse := res.(*elastic7.XPackWatcherGetWatchResponse)
 		watch, err = json.Marshal(watchResponse.Watch)
@@ -132,7 +137,11 @@ func resourceElasticsearchWatchUpdate(d *schema.ResourceData, m interface{}) err
 
 func resourceElasticsearchWatchDelete(d *schema.ResourceData, m interface{}) error {
 	var err error
-	switch client := m.(type) {
+	esClient, err := getClient(m.(*ProviderConf))
+	if err != nil {
+		return err
+	}
+	switch client := esClient.(type) {
 	case *elastic7.Client:
 		_, err = client.XPackWatchDelete(d.Id()).Do(context.TODO())
 	case *elastic6.Client:
@@ -147,7 +156,11 @@ func resourceElasticsearchWatchDelete(d *schema.ResourceData, m interface{}) err
 func resourceElasticsearchGetWatch(watchID string, m interface{}) (interface{}, error) {
 	var res interface{}
 	var err error
-	switch client := m.(type) {
+	esClient, err := getClient(m.(*ProviderConf))
+	if err != nil {
+		return "", err
+	}
+	switch client := esClient.(type) {
 	case *elastic7.Client:
 		res, err = client.XPackWatchGet(watchID).Do(context.TODO())
 	case *elastic6.Client:
@@ -164,7 +177,11 @@ func resourceElasticsearchPutWatch(d *schema.ResourceData, m interface{}) (strin
 	watchJSON := d.Get("body").(string)
 
 	var err error
-	switch client := m.(type) {
+	esClient, err := getClient(m.(*ProviderConf))
+	if err != nil {
+		return "", err
+	}
+	switch client := esClient.(type) {
 	case *elastic7.Client:
 		_, err = client.XPackWatchPut(watchID).
 			Body(watchJSON).

--- a/es/resource_elasticsearch_xpack_watch_test.go
+++ b/es/resource_elasticsearch_xpack_watch_test.go
@@ -21,8 +21,12 @@ func TestAccElasticsearchWatch(t *testing.T) {
 		t.Skipf("err: %s", err)
 	}
 	meta := provider.Meta()
+	esClient, err := getClient(meta.(*ProviderConf))
+	if err != nil {
+		t.Skipf("err: %s", err)
+	}
 	var allowed bool
-	switch meta.(type) {
+	switch esClient.(type) {
 	case *elastic5.Client:
 		allowed = false
 	default:

--- a/es/resource_elasticsearch_xpack_watch_test.go
+++ b/es/resource_elasticsearch_xpack_watch_test.go
@@ -22,11 +22,7 @@ func TestAccElasticsearchWatch(t *testing.T) {
 	}
 	meta := provider.Meta()
 	var allowed bool
-	esClient, err := getClient(meta.(*ProviderConf))
-	if err != nil {
-		t.Skipf("err: %s", err)
-	}
-	switch esClient.(type) {
+	switch meta.(type) {
 	case *elastic5.Client:
 		allowed = false
 	default:

--- a/es/resource_elasticsearch_xpack_watch_test.go
+++ b/es/resource_elasticsearch_xpack_watch_test.go
@@ -22,7 +22,11 @@ func TestAccElasticsearchWatch(t *testing.T) {
 	}
 	meta := provider.Meta()
 	var allowed bool
-	switch meta.(type) {
+	esClient, err := getClient(meta.(*ProviderConf))
+	if err != nil {
+		t.Skipf("err: %s", err)
+	}
+	switch esClient.(type) {
 	case *elastic5.Client:
 		allowed = false
 	default:
@@ -62,7 +66,11 @@ func testCheckElasticsearchWatchExists(name string) resource.TestCheckFunc {
 		meta := testAccXPackProvider.Meta()
 
 		var err error
-		switch client := meta.(type) {
+		esClient, err := getClient(meta.(*ProviderConf))
+		if err != nil {
+			return err
+		}
+		switch client := esClient.(type) {
 		case *elastic7.Client:
 			_, err = client.XPackWatchGet("my_watch").Do(context.TODO())
 		case *elastic6.Client:
@@ -87,7 +95,11 @@ func testCheckElasticsearchWatchDestroy(s *terraform.State) error {
 		meta := testAccXPackProvider.Meta()
 
 		var err error
-		switch client := meta.(type) {
+		esClient, err := getClient(meta.(*ProviderConf))
+		if err != nil {
+			return err
+		}
+		switch client := esClient.(type) {
 		case *elastic7.Client:
 			_, err = client.XPackWatchGet("my_watch").Do(context.TODO())
 		case *elastic6.Client:

--- a/go.sum
+++ b/go.sum
@@ -124,7 +124,6 @@ github.com/hashicorp/terraform-json v0.4.0 h1:KNh29iNxozP5adfUFBJ4/fWd0Cu3taGgjH
 github.com/hashicorp/terraform-json v0.4.0/go.mod h1:eAbqb4w0pSlRmdvl8fOyHAi/+8jnkVYN28gJkSJrLhU=
 github.com/hashicorp/terraform-plugin-sdk v1.12.0 h1:HPp65ShSsKUMPf6jD50UQn/xAjyrGVO4FxI63bvu+pc=
 github.com/hashicorp/terraform-plugin-sdk v1.12.0/go.mod h1:HiWIPD/T9HixIhQUwaSoDQxo4BLFdmiBi/Qz5gjB8Q0=
-github.com/hashicorp/terraform-plugin-sdk v1.16.0 h1:NrkXMRjHErUPPTHQkZ6JIn6bByiJzGnlJzH1rVdNEuE=
 github.com/hashicorp/terraform-plugin-test v1.3.0 h1:hU5LoxrOn9qvOo+LTKN6mSav2J+dAMprbdxJPEQvp4U=
 github.com/hashicorp/terraform-plugin-test v1.3.0/go.mod h1:QIJHYz8j+xJtdtLrFTlzQVC0ocr3rf/OjIpgZLK56Hs=
 github.com/hashicorp/terraform-svchost v0.0.0-20191011084731-65d371908596 h1:hjyO2JsNZUKT1ym+FAdlBEkGPevazYsmVgIMw7dVELg=

--- a/go.sum
+++ b/go.sum
@@ -124,6 +124,7 @@ github.com/hashicorp/terraform-json v0.4.0 h1:KNh29iNxozP5adfUFBJ4/fWd0Cu3taGgjH
 github.com/hashicorp/terraform-json v0.4.0/go.mod h1:eAbqb4w0pSlRmdvl8fOyHAi/+8jnkVYN28gJkSJrLhU=
 github.com/hashicorp/terraform-plugin-sdk v1.12.0 h1:HPp65ShSsKUMPf6jD50UQn/xAjyrGVO4FxI63bvu+pc=
 github.com/hashicorp/terraform-plugin-sdk v1.12.0/go.mod h1:HiWIPD/T9HixIhQUwaSoDQxo4BLFdmiBi/Qz5gjB8Q0=
+github.com/hashicorp/terraform-plugin-sdk v1.16.0 h1:NrkXMRjHErUPPTHQkZ6JIn6bByiJzGnlJzH1rVdNEuE=
 github.com/hashicorp/terraform-plugin-test v1.3.0 h1:hU5LoxrOn9qvOo+LTKN6mSav2J+dAMprbdxJPEQvp4U=
 github.com/hashicorp/terraform-plugin-test v1.3.0/go.mod h1:QIJHYz8j+xJtdtLrFTlzQVC0ocr3rf/OjIpgZLK56Hs=
 github.com/hashicorp/terraform-svchost v0.0.0-20191011084731-65d371908596 h1:hjyO2JsNZUKT1ym+FAdlBEkGPevazYsmVgIMw7dVELg=


### PR DESCRIPTION
While looking through I noticed several issues around being able to interpolate the provider. While this was an issue in previous version of terraform, it's been resolved. You can see in providers like [MySQL](https://github.com/terraform-providers/terraform-provider-mysql/blob/master/mysql/provider.go#L142-L146), the `providerConfigure` only returns a configuration struct. I've implemented the same pattern to allow for proper resource dependencies. I think a few tests might still have an issue, but I'll work to remediate these today. 

I think long term this code would benefit an interface around elastic search and a class factory to simply that logic, I tried to leave as much of the existing code alone as possible, as this is a large change already.

UPDATE: Running this locally and everything is running great. It's so nice to not use work arounds :) 
