### PR TITLE
Fix composable_index_template + tests

### DIFF
--- a/es/resource_elasticsearch_composable_index_template.go
+++ b/es/resource_elasticsearch_composable_index_template.go
@@ -49,8 +49,13 @@ func resourceElasticsearchComposableIndexTemplateRead(d *schema.ResourceData, me
 	id := d.Id()
 
 	var result, version string
-	var err error
-	switch client := meta.(type) {
+
+	esClient, err := getClient(meta.(*ProviderConf))
+	if err != nil {
+		return err
+	}
+
+	switch client := esClient.(type) {
 	case *elastic7.Client:
 		version, err = elastic7GetVersion(client)
 		if err == nil {
@@ -103,8 +108,13 @@ func resourceElasticsearchComposableIndexTemplateDelete(d *schema.ResourceData, 
 	id := d.Id()
 
 	var version string
-	var err error
-	switch client := meta.(type) {
+
+	esClient, err := getClient(meta.(*ProviderConf))
+	if err != nil {
+		return err
+	}
+
+	switch client := esClient.(type) {
 	case *elastic7.Client:
 		version, err = elastic7GetVersion(client)
 		if err == nil {
@@ -134,8 +144,12 @@ func resourceElasticsearchPutComposableIndexTemplate(d *schema.ResourceData, met
 	name := d.Get("name").(string)
 	body := d.Get("body").(string)
 
-	var err error
-	switch client := meta.(type) {
+	esClient, err := getClient(meta.(*ProviderConf))
+	if err != nil {
+		return err
+	}
+
+	switch client := esClient.(type) {
 	case *elastic7.Client:
 		err = elastic7PutIndexTemplate(client, name, body, create)
 	default:

--- a/es/resource_elasticsearch_composable_index_template_test.go
+++ b/es/resource_elasticsearch_composable_index_template_test.go
@@ -20,8 +20,14 @@ func TestAccElasticsearchComposableIndexTemplate(t *testing.T) {
 		t.Skipf("err: %s", err)
 	}
 	meta := provider.Meta()
+
+	esClient, err := getClient(meta.(*ProviderConf))
+	if err != nil {
+		t.Skipf("err: %s", err)
+	}
+
 	var allowed bool
-	switch meta.(type) {
+	switch esClient.(type) {
 	case *elastic7.Client:
 		allowed = true
 	default:
@@ -54,8 +60,14 @@ func TestAccElasticsearchComposableIndexTemplate_importBasic(t *testing.T) {
 		t.Skipf("err: %s", err)
 	}
 	meta := provider.Meta()
+
+	esClient, err := getClient(meta.(*ProviderConf))
+	if err != nil {
+		t.Skipf("err: %s", err)
+	}
+
 	var allowed bool
-	switch meta.(type) {
+	switch esClient.(type) {
 	case *elastic7.Client:
 		allowed = true
 	default:
@@ -95,8 +107,12 @@ func testCheckElasticsearchComposableIndexTemplateExists(name string) resource.T
 
 		meta := testAccProvider.Meta()
 
-		var err error
-		switch client := meta.(type) {
+		esClient, err := getClient(meta.(*ProviderConf))
+		if err != nil {
+			return err
+		}
+
+		switch client := esClient.(type) {
 		case *elastic7.Client:
 			_, err = client.IndexGetIndexTemplate(rs.Primary.ID).Do(context.TODO())
 		default:
@@ -119,8 +135,12 @@ func testCheckElasticsearchComposableIndexTemplateDestroy(s *terraform.State) er
 
 		meta := testAccProvider.Meta()
 
-		var err error
-		switch client := meta.(type) {
+		esClient, err := getClient(meta.(*ProviderConf))
+		if err != nil {
+			return err
+		}
+
+		switch client := esClient.(type) {
 		case *elastic7.Client:
 			_, err = client.IndexGetTemplate(rs.Primary.ID).Do(context.TODO())
 		default:


### PR DESCRIPTION
The composable index_template code was attempting to type switch on
`meta` instead of the result of `getClient`. Since `meta` is not a
client, but rather a `ProviderConf` this caused the 'default' case of
the type switch to run which made the tests skip and not fail.

### Real World Output
```
Error: index_template endpoint only available from ElasticSearch >= 7.8, got version < 7.0.0 (*es.ProviderConf)
```

### Test Output Before PR
```
$ TF_ACC=1 go test ./... -v -run TestAccElasticsearchComposableIndexTemplate
?   	github.com/phillbaker/terraform-provider-elasticsearch	[no test files]
=== RUN   TestAccElasticsearchComposableIndexTemplate
    TestAccElasticsearchComposableIndexTemplate: resource_elasticsearch_composable_index_template_test.go:34: /_index_template endpoint only supported on ES >= 7.8
--- SKIP: TestAccElasticsearchComposableIndexTemplate (0.00s)
=== RUN   TestAccElasticsearchComposableIndexTemplate_importBasic
    TestAccElasticsearchComposableIndexTemplate_importBasic: resource_elasticsearch_composable_index_template_test.go:68: /_index_template endpoint only supported on ES >= 7.8
--- SKIP: TestAccElasticsearchComposableIndexTemplate_importBasic (0.00s)
PASS
ok  	github.com/phillbaker/terraform-provider-elasticsearch/es	0.065s
```

### Test Output After PR
```
$ TF_ACC=1 go test ./... -v -run TestAccElasticsearchComposableIndexTemplate 2>/dev/null
?   	github.com/phillbaker/terraform-provider-elasticsearch	[no test files]
=== RUN   TestAccElasticsearchComposableIndexTemplate
2020/12/23 19:50:36 [INFO] Pinging url to determine version http://127.0.0.1:9200
2020/12/23 19:50:36 [INFO] terraform: building graph: GraphTypeValidate
2020/12/23 19:50:36 [INFO] terraform: building graph: GraphTypeRefresh
2020/12/23 19:50:36 [INFO] terraform: building graph: GraphTypePlan
2020/12/23 19:50:36 [WARN] Test: Step plan: DIFF:

CREATE: elasticsearch_composable_index_template.test
  body: "" => "{\n  \"index_patterns\": [\"te*\", \"bar*\"],\n  \"template\": {\n    \"settings\": {\n      \"index\": {\n        \"number_of_shards\": 1\n      }\n    },\n    \"mappings\": {\n      \"properties\": {\n        \"host_name\": {\n          \"type\": \"keyword\"\n        },\n        \"created_at\": {\n          \"type\": \"date\",\n          \"format\": \"EEE MMM dd HH:mm:ss Z yyyy\"\n        }\n      }\n    },\n    \"aliases\": {\n      \"mydata\": { }\n    }\n  },\n  \"priority\": 200,\n  \"version\": 3\n}\n"
  id:   "" => "<computed>"
  name: "" => "terraform-test"



STATE:

<no state>
2020/12/23 19:50:36 [INFO] terraform: building graph: GraphTypeApply
2020/12/23 19:50:36 [INFO] Pinging url to determine version http://127.0.0.1:9200
2020/12/23 19:50:36 [INFO] terraform: building graph: GraphTypePlan
2020/12/23 19:50:36 [INFO] terraform: building graph: GraphTypeRefresh
2020/12/23 19:50:36 [INFO] Pinging url to determine version http://127.0.0.1:9200
2020/12/23 19:50:36 [INFO] terraform: building graph: GraphTypePlan
2020/12/23 19:50:36 [WARN] Test: Executing destroy step
2020/12/23 19:50:36 [INFO] terraform: building graph: GraphTypeValidate
2020/12/23 19:50:36 [INFO] terraform: building graph: GraphTypeRefresh
2020/12/23 19:50:37 [INFO] Pinging url to determine version http://127.0.0.1:9200
2020/12/23 19:50:37 [INFO] terraform: building graph: GraphTypePlanDestroy
2020/12/23 19:50:37 [WARN] Test: Step plan: DIFF:

DESTROY: elasticsearch_composable_index_template.test
  body: "{\"index_patterns\":[\"te*\",\"bar*\"],\"priority\":200,\"version\":3,\"template\":{\"settings\":{\"index\":{\"number_of_shards\":\"1\"}},\"mappings\":{\"properties\":{\"created_at\":{\"format\":\"EEE MMM dd HH:mm:ss Z yyyy\",\"type\":\"date\"},\"host_name\":{\"type\":\"keyword\"}}},\"aliases\":{\"mydata\":{}}}}" => ""
  id:   "terraform-test" => ""
  name: "terraform-test" => ""



STATE:

elasticsearch_composable_index_template.test:
  ID = terraform-test
  provider = provider.elasticsearch
  body = {"index_patterns":["te*","bar*"],"priority":200,"version":3,"template":{"settings":{"index":{"number_of_shards":"1"}},"mappings":{"properties":{"created_at":{"format":"EEE MMM dd HH:mm:ss Z yyyy","type":"date"},"host_name":{"type":"keyword"}}},"aliases":{"mydata":{}}}}
  name = terraform-test
2020/12/23 19:50:37 [INFO] terraform: building graph: GraphTypeApply
2020/12/23 19:50:37 DestroyEdgeTransformer: pruning unused resource node elasticsearch_composable_index_template.test (prepare state)
2020/12/23 19:50:37 [INFO] Pinging url to determine version http://127.0.0.1:9200
2020/12/23 19:50:37 [INFO] terraform: building graph: GraphTypePlanDestroy
2020/12/23 19:50:37 [INFO] terraform: building graph: GraphTypeRefresh
2020/12/23 19:50:37 [INFO] terraform: building graph: GraphTypePlanDestroy
--- PASS: TestAccElasticsearchComposableIndexTemplate (0.28s)
=== RUN   TestAccElasticsearchComposableIndexTemplate_importBasic
2020/12/23 19:50:37 [INFO] Pinging url to determine version http://127.0.0.1:9200
2020/12/23 19:50:37 [INFO] terraform: building graph: GraphTypeValidate
2020/12/23 19:50:37 [INFO] terraform: building graph: GraphTypeRefresh
2020/12/23 19:50:37 [INFO] terraform: building graph: GraphTypePlan
2020/12/23 19:50:37 [WARN] Test: Step plan: DIFF:

CREATE: elasticsearch_composable_index_template.test
  body: "" => "{\n  \"index_patterns\": [\"te*\", \"bar*\"],\n  \"template\": {\n    \"settings\": {\n      \"index\": {\n        \"number_of_shards\": 1\n      }\n    },\n    \"mappings\": {\n      \"properties\": {\n        \"host_name\": {\n          \"type\": \"keyword\"\n        },\n        \"created_at\": {\n          \"type\": \"date\",\n          \"format\": \"EEE MMM dd HH:mm:ss Z yyyy\"\n        }\n      }\n    },\n    \"aliases\": {\n      \"mydata\": { }\n    }\n  },\n  \"priority\": 200,\n  \"version\": 3\n}\n"
  id:   "" => "<computed>"
  name: "" => "terraform-test"



STATE:

<no state>
2020/12/23 19:50:37 [INFO] terraform: building graph: GraphTypeApply
2020/12/23 19:50:37 [INFO] Pinging url to determine version http://127.0.0.1:9200
2020/12/23 19:50:37 [INFO] terraform: building graph: GraphTypePlan
2020/12/23 19:50:37 [INFO] terraform: building graph: GraphTypeRefresh
2020/12/23 19:50:37 [INFO] Pinging url to determine version http://127.0.0.1:9200
2020/12/23 19:50:37 [INFO] terraform: building graph: GraphTypePlan
2020/12/23 19:50:37 [INFO] Pinging url to determine version http://127.0.0.1:9200
2020/12/23 19:50:37 [WARN] Test: Executing destroy step
2020/12/23 19:50:37 [INFO] terraform: building graph: GraphTypeValidate
2020/12/23 19:50:37 [WARN] Not fixing up EachModes for elasticsearch_composable_index_template.test because it has no config
2020/12/23 19:50:37 [INFO] terraform: building graph: GraphTypeRefresh
2020/12/23 19:50:37 [INFO] Pinging url to determine version http://127.0.0.1:9200
2020/12/23 19:50:37 [INFO] terraform: building graph: GraphTypePlanDestroy
2020/12/23 19:50:37 [WARN] Test: Step plan: DIFF:

DESTROY: elasticsearch_composable_index_template.test
  body: "{\"index_patterns\":[\"te*\",\"bar*\"],\"priority\":200,\"version\":3,\"template\":{\"settings\":{\"index\":{\"number_of_shards\":\"1\"}},\"mappings\":{\"properties\":{\"created_at\":{\"format\":\"EEE MMM dd HH:mm:ss Z yyyy\",\"type\":\"date\"},\"host_name\":{\"type\":\"keyword\"}}},\"aliases\":{\"mydata\":{}}}}" => ""
  id:   "terraform-test" => ""
  name: "terraform-test" => ""



STATE:

elasticsearch_composable_index_template.test:
  ID = terraform-test
  provider = provider.elasticsearch
  body = {"index_patterns":["te*","bar*"],"priority":200,"version":3,"template":{"settings":{"index":{"number_of_shards":"1"}},"mappings":{"properties":{"created_at":{"format":"EEE MMM dd HH:mm:ss Z yyyy","type":"date"},"host_name":{"type":"keyword"}}},"aliases":{"mydata":{}}}}
  name = terraform-test
2020/12/23 19:50:37 [INFO] terraform: building graph: GraphTypeApply
2020/12/23 19:50:37 [INFO] Pinging url to determine version http://127.0.0.1:9200
2020/12/23 19:50:37 [INFO] terraform: building graph: GraphTypePlanDestroy
2020/12/23 19:50:37 [INFO] terraform: building graph: GraphTypeRefresh
2020/12/23 19:50:37 [INFO] terraform: building graph: GraphTypePlanDestroy
--- PASS: TestAccElasticsearchComposableIndexTemplate_importBasic (0.32s)
PASS
ok  	github.com/phillbaker/terraform-provider-elasticsearch/es	(cached)
```