### PR TITLE
Small fix for elasticsearch_snapshot_repository docs

### DIFF
--- a/docs/resources/snapshot_repository.md
+++ b/docs/resources/snapshot_repository.md
@@ -17,7 +17,7 @@ Provides an Elasticsearch snapshot repository resource.
 resource "elasticsearch_snapshot_repository" "repo" {
   name = "es-index-backups"
   type = "s3"
-  settings {
+  settings = {
     bucket = "es-index-backups"
     region = "us-east-1"
     role_arn = "arn:aws:iam::123456789012:role/MyElasticsearchRole"


### PR DESCRIPTION
The setting argument needs to be assigned to, not referenced as a block.