### PR TITLE
Add "id" to normalizeDestination to account for nested "id" key in newer versions of ES

### DIFF
--- a/es/resource_elasticsearch_opendistro_destination.go
+++ b/es/resource_elasticsearch_opendistro_destination.go
@@ -216,8 +216,6 @@ func resourceElasticsearchOpenDistroPostDestination(d *schema.ResourceData, m in
 		return response, fmt.Errorf("error unmarshalling destination body: %+v: %+v", err, body)
 	}
 
-	normalizeDestination(response.Destination.(map[string]interface{}))
-
 	return response, nil
 }
 

--- a/es/resource_elasticsearch_opendistro_destination.go
+++ b/es/resource_elasticsearch_opendistro_destination.go
@@ -164,8 +164,6 @@ func resourceElasticsearchOpenDistroGetDestination(destinationID string, m inter
 		return "", fmt.Errorf("error unmarshalling destination body: %+v: %+v", err, body)
 	}
 
-	normalizeDestination(response.Destination.(map[string]interface{}))
-
 	tj, err := json.Marshal(response.Destination)
 	if err != nil {
 		return "", err

--- a/es/util.go
+++ b/es/util.go
@@ -73,6 +73,7 @@ func elastic5GetObject(client *elastic5.Client, objectType string, index string,
 }
 
 func normalizeDestination(tpl map[string]interface{}) {
+	delete(tpl, "id")
 	delete(tpl, "last_update_time")
 	delete(tpl, "schema_version")
 }


### PR DESCRIPTION
~The normalizeDestination function already exists but isn't being used in the function to GET destinations. This adds that step, as well as~. I'm an idiot. The normalizeDestination gets called via the diffsuppress.

Adds "id" to the list of keys to ignore. The "id" is a nested v alue that gets created with the lastest versions of ES.