### PR TITLE
Normalize IDs in resource_elasticsearch_opendistro_monitor

### DIFF
--- a/es/util.go
+++ b/es/util.go
@@ -79,9 +79,33 @@ func normalizeDestination(tpl map[string]interface{}) {
 }
 
 func normalizeMonitor(tpl map[string]interface{}) {
+	if triggers, ok := tpl["triggers"].([]interface{}); ok {
+		normalizeMonitorTriggers(triggers)
+	}
+
+	delete(tpl, "id")
 	delete(tpl, "last_update_time")
 	delete(tpl, "enabled_time")
 	delete(tpl, "schema_version")
+}
+
+func normalizeMonitorTriggers(triggers []interface{}) {
+	for _, t := range triggers {
+		if trigger, ok := t.(map[string]interface{}); ok {
+			delete(trigger, "id")
+
+			if actions, ok := trigger["actions"].([]interface{}); ok {
+				normalizeMonitorTriggerActions(actions)
+			}
+		}
+	}
+}
+
+func normalizeMonitorTriggerActions(actions []interface{}) {
+	for _, a := range actions {
+		action := a.(map[string]interface{})
+		delete(action, "id")
+	}
 }
 
 func normalizePolicy(tpl map[string]interface{}) {


### PR DESCRIPTION
Observed that after creating an `elasticsearch_opendistro_monitor` resource, diffs are perpetually caused by the monitor's `id` and its action/trigger `id` values, which are added after creation by the API.  These will always change between applies, as this diff causes them to be re-created.

This PR suppresses the diff on subsequent applies by normalizing out those IDs.

<details>
<summary>
Demonstration of the issue:
</summary>

```
An execution plan has been generated and is shown below.
Resource actions are indicated with the following symbols:
  ~ update in-place

Terraform will perform the following actions:

  # elasticsearch_opendistro_monitor.test_alert will be updated in-place
  ~ resource "elasticsearch_opendistro_monitor" "test_alert" {
      ~ body = jsonencode(
          ~ {
              + schema_version = 3
              ~ triggers       = [
                  ~ {
                      ~ actions   = [
                          ~ {
                              - id               = "ddhSrXgBFOIThFuLg4Hw" -> null
                                # (6 unchanged elements hidden)
                            },
                        ]
                      - id        = "dNhSrXgBFOIThFuLg4Hw" -> null
                        # (3 unchanged elements hidden)
                    },
                ]
                # (6 unchanged elements hidden)
            }
        )
        id   = "t0_Zq3gCq8zSspID5O1B"
    }

Plan: 0 to add, 1 to change, 0 to destroy.
```
</details>

<details>
<summary>Again on another apply:</summary>

```
Terraform will perform the following actions:

  # elasticsearch_opendistro_monitor.test_alert will be updated in-place
  ~ resource "elasticsearch_opendistro_monitor" "test_alert" {
      ~ body = jsonencode(
          ~ {
              + schema_version = 3
              ~ triggers       = [
                  ~ {
                      ~ actions   = [
                          ~ {
                              - id               = "jtuBsHgBHOIThFuLAdJu" -> null
                                # (6 unchanged elements hidden)
                            },
                        ]
                      - id        = "jduBsHgBHOIThFuLAdJu" -> null
                        # (3 unchanged elements hidden)
                    },
                ]
                # (6 unchanged elements hidden)
            }
        )
        id   = "t0_Zq3gCq8zSspID5O1B"
    }

Plan: 0 to add, 1 to change, 0 to destroy.
```
</details>