### PR TITLE
Support configuring provider token from environment

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -67,7 +67,7 @@ The following arguments are supported:
 * `aws_token` (Optional) - The session token for use with AWS Elasticsearch Service domains. It can also be sourced from the `AWS_SESSION_TOKEN` environment variable.
 * `aws_profile` (Optional) - The AWS profile for use with AWS Elasticsearch Service domains
 * `aws_region` (Optional) - The AWS region for use in signing of AWS elasticsearch requests. Must be specified in order to use AWS URL signing with AWS ElasticSearch endpoint exposed on a custom DNS domain.
-* `token` (Optional) - A bearer token or ApiKey for an Authorization header, e.g. Active Directory API key. See the [docs](https://www.elastic.co/guide/en/elasticsearch/reference/master/token-authentication-services.html).
+* `token` (Optional) - A bearer token or ApiKey for an Authorization header, e.g. Active Directory API key. See the [docs](https://www.elastic.co/guide/en/elasticsearch/reference/master/token-authentication-services.html). Defaults to `ELASTICSEARCH_TOKEN` from the environment
 * `token_name` (Optional) - The type of token, usually ApiKey or Bearer. Defaults to ApiKey.
 * `cacert_file` (Optional) - a custom CA certificate when communicating over SSL. You can specify either a path to the file or the contents of the certificate.
 * `insecure` (Optional) - Disable SSL verification of API calls (defaults to `false`)

--- a/es/provider.go
+++ b/es/provider.go
@@ -87,7 +87,7 @@ func Provider() terraform.ResourceProvider {
 			"token": {
 				Type:        schema.TypeString,
 				Optional:    true,
-				Default:     "",
+				DefaultFunc: schema.EnvDefaultFunc("ELASTICSEARCH_TOKEN", nil),
 				Description: "A bearer token or ApiKey for an Authorization header, e.g. Active Directory API key.",
 			},
 			"token_name": {


### PR DESCRIPTION
This changes the default value of the provider `token` field to read
from the environment variable `ELASTICSEARCH_TOKEN`.

fixes #179