### PR TITLE
[doc] Index Lifecycle Management fix link to xpack doc

### DIFF
--- a/docs/resources/xpack_index_lifecycle_policy.md
+++ b/docs/resources/xpack_index_lifecycle_policy.md
@@ -8,7 +8,7 @@ description: |-
 
 # elasticsearch_xpack_index_lifecycle_policy
 
-Provides an Elasticsearch xpack index lifecycle policy resource. Please see [docs](https://www.elastic.co/guide/en/elasticsearch/reference/current/snapshot-lifecycle-management-api.html) for more details on usage.
+Provides an Elasticsearch xpack index lifecycle policy resource. Please see [docs](https://www.elastic.co/guide/en/elasticsearch/reference/current/index-lifecycle-management-api.html) for more details on usage.
 
 ## Example Usage
 


### PR DESCRIPTION
Just a small fix for the ILM policy link to the API docs in es-xpack.