### PR TITLE
[aws] Also load shared config for a profile

### DIFF
--- a/es/provider.go
+++ b/es/provider.go
@@ -473,6 +473,7 @@ func awsSession(region string, conf *ProviderConf) *awssession.Session {
 		sessOpts.Config.Credentials = assumeRoleCredentials(region, conf.awsAssumeRoleArn, conf.awsProfile)
 	} else if conf.awsProfile != "" {
 		sessOpts.Profile = conf.awsProfile
+		sessOpts.SharedConfigState = awssession.SharedConfigEnable
 	}
 
 	// If configured as insecure, turn off SSL verification


### PR DESCRIPTION
Profiles are defined in the shared config file so it makes sense to load that too.

Or should this be on line 461 as part of the initialisation of the `sessOpts`?

Follow up to 72475b5

My usecase: Only providing the profile name without needing the environment variable `AWS_SDK_LOAD_CONFIG=1`