### PR TITLE
Fix updates on index settings with '.' in name

### DIFF
--- a/es/resource_elasticsearch_index.go
+++ b/es/resource_elasticsearch_index.go
@@ -606,8 +606,9 @@ func allowIndexDestroy(indexName string, d *schema.ResourceData, meta interface{
 func resourceElasticsearchIndexUpdate(d *schema.ResourceData, meta interface{}) error {
 	settings := make(map[string]interface{})
 	for _, key := range settingsKeys {
-		if d.HasChange(key) {
-			settings[key] = d.Get(key)
+		schemaName := strings.Replace(key, ".", "_", -1)
+		if d.HasChange(schemaName) {
+			settings[key] = d.Get(schemaName)
 		}
 	}
 


### PR DESCRIPTION
This PR resolves https://github.com/phillbaker/terraform-provider-elasticsearch/issues/194. Index settings with a `.` in their name were only set at creation time, and never at update time due to a missed `strings.Replace(key, ".", "_", -1)`.

I've tested this locally using the same setup described in the issue, and get the expected behaviour where an update to the index block in terraform is respected by the cluster.

I'm not sure if there's a changelog or anything else I should update here - let me know @phillbaker, and thanks for all your work on this module 😄 