### PR TITLE
Pass conf.insecure correctly in awsHttpClient()

### DIFF
--- a/es/provider.go
+++ b/es/provider.go
@@ -488,8 +488,9 @@ func awsSession(region string, conf *ProviderConf) *awssession.Session {
 }
 
 func awsHttpClient(region string, conf *ProviderConf, headers map[string]string) *http.Client {
-	signer := awssigv4.NewSigner(awsSession(region, conf).Config.Credentials)
-	client, err := aws_signing_client.New(signer, nil, "es", region)
+	session := awsSession(region, conf)
+	signer := awssigv4.NewSigner(session.Config.Credentials)
+	client, err := aws_signing_client.New(signer, session.Config.HTTPClient, "es", region)
 	if err != nil {
 		log.Fatal(err)
 	}


### PR DESCRIPTION
This PR resolves https://github.com/phillbaker/terraform-provider-elasticsearch/issues/177. The setup is a cluster running in an AWS VPC, which i am connecting to via an SSH tunnel on `localhost:9999`. I recieved the following error regardless of what the `insecure` option was set to:
```
Error: Get "https://localhost:9999/terraform-test/_settings?flat_settings=true": x509: certificate is valid for *.us-east-1.es.amazonaws.com, not localhost
```

This is because `insecure` is used to set the TLS options on the client created in `awsSession()`, but that client is not passed through to `aws_signing_client.New()`, resulting in `http.DefaultClient` being used instead. By passing the client through, certificate validation is skipped as expected.