### PR TITLE
Add host_override parameter to allow connections via SSH tunnel with `sign_aws_requests = true`

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -75,6 +75,7 @@ The following arguments are supported:
 * `client_key_path` (Optional) - A X509 key to connect to elasticsearch. Defaults to `ES_CLIENT_KEY_PATH`
 * `sign_aws_requests` (Optional) - Enable signing of AWS elasticsearch requests (defauls to `true`). The `url` must refer to AWS ES domain (`*.<region>.es.amazonaws.com`), or `aws_region` must be specified explicitly.
 * `elasticsearch_version` (Optional) - ElasticSearch Version, if set, skips the version detection at provider start.
+* `host_override` (Optional) - If provided, sets the 'Host' header of requests and the 'ServerName' for certificate validation to this value. See the documentation on connecting to Elasticsearch via an SSH tunnel.
 
 ### AWS authentication
 
@@ -143,3 +144,16 @@ provider "elasticsearch" {
 You can use an AWS credentials file to specify your credentials. The default location is `$HOME/.aws/credentials` on Linux and macOS, or `%USERPROFILE%\.aws\credentials` for Windows users.
 
 Please refer to the official [userguide](https://docs.aws.amazon.com/cli/latest/userguide/cli-config-files.html) for instructions on how to create the credentials file.
+
+### Connecting to Elasticsearch via an SSH Tunnel
+
+If you need to connect to an Elasticsearch cluster via an SSH tunnel (for example, to an AWS VPC Cluster), set the following configuration options in your provider:
+
+```
+provider "elasticsearch" {
+  url   = "https://localhost:9999" # Replace 9999 with the port your SSH tunnel is running on
+  host_override = "vpc-<******>.us-east-1.es.amazonaws.com"
+}
+```
+
+The `host_override` flag will set the `Host` header of requests to Elasticsearch and the `ServerName` used for certificate validation. It is recommended to set this flag instead of `insecure = true`, which causes certificate validation to be skipped. Note that if both `host_override` and `insecure = true` are set, certificate validation will be skipped and the `Host` header will be overriden.

--- a/es/http.go
+++ b/es/http.go
@@ -6,7 +6,8 @@ import (
 
 type withHeader struct {
 	http.Header
-	rt http.RoundTripper
+	hostOverride string
+	rt           http.RoundTripper
 }
 
 func WithHeader(rt http.RoundTripper) withHeader {
@@ -20,6 +21,9 @@ func WithHeader(rt http.RoundTripper) withHeader {
 func (h withHeader) RoundTrip(req *http.Request) (*http.Response, error) {
 	for k, v := range h.Header {
 		req.Header[k] = v
+	}
+	if h.hostOverride != "" {
+		req.Host = h.hostOverride
 	}
 
 	return h.rt.RoundTrip(req)


### PR DESCRIPTION
## Overview

This PR adds a new provider configuration option `host_override`. The option enables the use of `sign_aws_requests = true` when accessing Elasticsearch via an SSH tunnel, as well as removing the need to set `insecure = true`.

I've also added a note to the documentation detailing when this parameter should be used. Happy to change the naming if there's terms you think would work better too!

## Issue

Consider the following example - an SSH tunnel is setup on `localhost:9999`, pointing to an AWS VPC cluster `vpc-<******>.us-east-1.es.amazonaws.com`. Without using `insecure = true`, the connection will error with the following:

> Error: health check timeout: Head "https://localhost:9999": x509: certificate is valid for *.us-east-1.es.amazonaws.com, not localhost: no Elasticsearch node available

While `insecure = true` can be set to workaround this issue, clusters with [IAM](https://docs.aws.amazon.com/elasticsearch-service/latest/developerguide/es-ac.html) policies will also require `sign_aws_requests = true`. This leads to the following cryptic error:

> Error: health check timeout: no Elasticsearch node available


By modifying the logging for the signing client (I hacked around by setting `aws_signing_client.SetDebugLog(log.Default())` and compiling against Go 1.16) we can see that the underlying failure is caused by a 403:

> 2021-07-16T09:21:09.968+1000 [DEBUG] plugin.terraform-provider-elasticsearch: 2021/07/16 09:21:09 Successful response from RoundTripper: &{Status:403 Forbidden StatusCode:403 Proto:HTTP/1.1 ProtoMajor:1 ProtoMinor:1 Header:map[Access-Control-Allow-Origin:[*] Connection:[keep-alive] Content-Length:[192] Content-Type:[application/json] Date:[Thu, 15 Jul 2021 23:21:09 GMT] X-Amzn-Requestid:[<redacted>]] Body:{Reader:<redacted>} ContentLength:192 TransferEncoding:[] Close:false Uncompressed:false Trailer:map[] Request:<redacted> TLS:<redacted>}

The 403 is caused because sigv4 uses the `host` header in the request as part of the [signing process](https://docs.aws.amazon.com/general/latest/gr/sigv4-create-canonical-request.html). Since the `host` is set to `localhost` rather than `vpc-<******>.us-east-1.es.amazonaws.com`, the signing process calculates an invalid authentication token.

## Solution in this PR

This PR adds `host_override` as a parameter. When set, the provided value will override the `Host` of the HTTPClient:

```
if h.hostOverride != "" {
    req.Host = h.hostOverride
}
```

This resolves the 403 issue as the signature process is now using the correct host.

The PR also goes a step further an uses the host override to set the `ServerName` in the TLS options:

```
} else if conf.hostOverride != "" {
	client := &http.Client{Transport: &http.Transport{
		TLSClientConfig: &tls.Config{ServerName: conf.hostOverride},
	}}
	sessOpts.Config.HTTPClient = client
}
```

From the [tls package documentation](https://pkg.go.dev/crypto/tls#Config):

```
// ServerName is used to verify the hostname on the returned
// certificates unless InsecureSkipVerify is given. It is also included
// in the client's handshake to support virtual hosting unless it is
// an IP address.
ServerName string
```

This removes the need for setting `insecure = true` when using an SSH tunnel, as the certificate returned will match the `ServerName` provided.

## Possible Alternatives

As noted in https://github.com/phillbaker/terraform-provider-elasticsearch/issues/177#issuecomment-870309708, one workaround for this problem is to override the `/etc/hosts` file such that `vpc-<******>.us-east-1.es.amazonaws.com` resolves to `localhost`. However, this is not practical when managing a large number of clusters or in CI environments.
