### PR TITLE
[provider] Output ES Client Logs depending on TF_LOG_PROVIDER

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /vendor
+terraform-provider-elasticsearch

--- a/es/provider.go
+++ b/es/provider.go
@@ -9,7 +9,9 @@ import (
 	"log"
 	"net/http"
 	"net/url"
+	"os"
 	"regexp"
+	"strings"
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -290,6 +292,24 @@ func getClient(conf *ProviderConf) (interface{}, error) {
 		opts = append(opts, elastic7.SetHttpClient(tokenHttpClient(conf, map[string]string{})), elastic7.SetSniff(false))
 	} else {
 		opts = append(opts, elastic7.SetHttpClient(defaultHttpClient(conf, map[string]string{})))
+	}
+
+	log_provider_level, ok := os.LookupEnv("TF_LOG_PROVIDER")
+	if !ok {
+		log_provider_level = "ERROR"
+	}
+
+	log_provider_level = strings.ToUpper(log_provider_level)
+
+	switch log_provider_level {
+	case "TRACE":
+		opts = append(opts, elastic7.SetTraceLog(log.Default()))
+		fallthrough
+	case "INFO":
+		opts = append(opts, elastic7.SetInfoLog(log.Default()))
+		fallthrough
+	default:
+		opts = append(opts, elastic7.SetErrorLog(log.Default()))
 	}
 
 	var relevantClient interface{}


### PR DESCRIPTION
This change exposes the underlying Elasticsearch client library logs, which provides significantly more details about requests made to a domain. This is more of an RFC than anything else, since I'm not sure this is the right way to go about this.

Before I'd just get an `Access Denied` error, but my `TRACE` logs now include much more helpful details:

```
{"status":"FORBIDDEN","message":"No permission to access REST API: User arn:aws:iam::9001:user/yasumoto with Security roles [all_access] does not have any role privileged for admin access. No ssl info found in request."}: timestamp=2021-11-16T13:04:32.116-0800
```

Note this format does not follow the expected [prefix pattern](https://www.terraform.io/docs/extend/debugging.html#inserting-log-lines-into-a-provider) and just reads the environment variable like the [Kubernetes provider](https://github.com/hashicorp/terraform-provider-kubernetes/blob/5481e8926799c1a14c34332b8891e1f1a53db90b/manifest/provider/plugin.go#L27). We probably need to figure out a better formatting method before shipping this.

I found this [phenomenal breakdown](https://github.com/hashicorp/terraform-plugin-sdk/issues/695) about logging, which leads to a lot more resources as well.

There are a few other options here, such as just printing out more detailed error responses. Howewver, when I tried to print out the `response` (not just the `err`) from [`resourceElasticsearchPutOpenDistroRolesMapping`](https://github.com/phillbaker/terraform-provider-elasticsearch/blob/master/es/resource_elasticsearch_opendistro_roles_mapping.go#L62) it looked like that object was empty. Very open to alternatives here, but I think the key is providing better debug output. Thanks again for all the great work on this provider!