### PR TITLE
Use esVersion from ProviderConf to compare versions

### DIFF
--- a/es/resource_elasticsearch_component_template.go
+++ b/es/resource_elasticsearch_component_template.go
@@ -57,14 +57,15 @@ func resourceElasticsearchComponentTemplateRead(d *schema.ResourceData, meta int
 	var result string
 	var elasticVersion *version.Version
 
-	esClient, err := getClient(meta.(*ProviderConf))
+	providerConf := meta.(*ProviderConf)
+	esClient, err := getClient(providerConf)
 	if err != nil {
 		return err
 	}
 
 	switch client := esClient.(type) {
 	case *elastic7.Client:
-		elasticVersion, err = elastic7GetVersion(client)
+		elasticVersion, err = version.NewVersion(providerConf.esVersion)
 		if err == nil {
 			if elasticVersion.LessThan(componentTemplateMinimalVersion) {
 				err = fmt.Errorf("component_template endpoint only available from ElasticSearch >= 7.8, got version %s", elasticVersion.String())
@@ -116,14 +117,15 @@ func resourceElasticsearchComponentTemplateDelete(d *schema.ResourceData, meta i
 
 	var elasticVersion *version.Version
 
-	esClient, err := getClient(meta.(*ProviderConf))
+	providerConf := meta.(*ProviderConf)
+	esClient, err := getClient(providerConf)
 	if err != nil {
 		return err
 	}
 
 	switch client := esClient.(type) {
 	case *elastic7.Client:
-		elasticVersion, err = elastic7GetVersion(client)
+		elasticVersion, err = version.NewVersion(providerConf.esVersion)
 		if err == nil {
 			if elasticVersion.LessThan(componentTemplateMinimalVersion) {
 				err = fmt.Errorf("component_template endpoint only available from ElasticSearch >= 7.8, got version %s", elasticVersion.String())
@@ -153,14 +155,15 @@ func resourceElasticsearchPutComponentTemplate(d *schema.ResourceData, meta inte
 
 	var elasticVersion *version.Version
 
-	esClient, err := getClient(meta.(*ProviderConf))
+	providerConf := meta.(*ProviderConf)
+	esClient, err := getClient(providerConf)
 	if err != nil {
 		return err
 	}
 
 	switch client := esClient.(type) {
 	case *elastic7.Client:
-		elasticVersion, err = elastic7GetVersion(client)
+		elasticVersion, err = version.NewVersion(providerConf.esVersion)
 		if err == nil {
 			if elasticVersion.LessThan(componentTemplateMinimalVersion) {
 				err = fmt.Errorf("component_template endpoint only available from ElasticSearch >= 7.8, got version %s", elasticVersion.String())

--- a/es/resource_elasticsearch_composable_index_template.go
+++ b/es/resource_elasticsearch_composable_index_template.go
@@ -54,14 +54,15 @@ func resourceElasticsearchComposableIndexTemplateRead(d *schema.ResourceData, me
 	var result string
 	var elasticVersion *version.Version
 
-	esClient, err := getClient(meta.(*ProviderConf))
+	providerConf := meta.(*ProviderConf)
+	esClient, err := getClient(providerConf)
 	if err != nil {
 		return err
 	}
 
 	switch client := esClient.(type) {
 	case *elastic7.Client:
-		elasticVersion, err = elastic7GetVersion(client)
+		elasticVersion, err = version.NewVersion(providerConf.esVersion)
 		if err == nil {
 			if elasticVersion.LessThan(minimalESComposableTemplateVersion) {
 				err = fmt.Errorf("index_template endpoint only available from ElasticSearch >= 7.8, got version %s", elasticVersion.String())
@@ -113,14 +114,15 @@ func resourceElasticsearchComposableIndexTemplateDelete(d *schema.ResourceData, 
 
 	var elasticVersion *version.Version
 
-	esClient, err := getClient(meta.(*ProviderConf))
+	providerConf := meta.(*ProviderConf)
+	esClient, err := getClient(providerConf)
 	if err != nil {
 		return err
 	}
 
 	switch client := esClient.(type) {
 	case *elastic7.Client:
-		elasticVersion, err = elastic7GetVersion(client)
+		elasticVersion, err = version.NewVersion(providerConf.esVersion)
 		if err == nil {
 			if elasticVersion.LessThan(minimalESComposableTemplateVersion) {
 				err = fmt.Errorf("index_template endpoint only available from ElasticSearch >= 7.8, got version %s", elasticVersion.String())
@@ -150,14 +152,15 @@ func resourceElasticsearchPutComposableIndexTemplate(d *schema.ResourceData, met
 
 	var elasticVersion *version.Version
 
-	esClient, err := getClient(meta.(*ProviderConf))
+	providerConf := meta.(*ProviderConf)
+	esClient, err := getClient(providerConf)
 	if err != nil {
 		return err
 	}
 
 	switch client := esClient.(type) {
 	case *elastic7.Client:
-		elasticVersion, err = elastic7GetVersion(client)
+		elasticVersion, err = version.NewVersion(providerConf.esVersion)
 		if err == nil {
 			if elasticVersion.LessThan(minimalESComposableTemplateVersion) {
 				err = fmt.Errorf("index_template endpoint only available from ElasticSearch >= 7.8, got version %s", elasticVersion.String())

--- a/es/resource_elasticsearch_kibana_alert.go
+++ b/es/resource_elasticsearch_kibana_alert.go
@@ -208,7 +208,8 @@ func resourceElasticsearchKibanaAlertRead(d *schema.ResourceData, meta interface
 
 	var alert kibana.Alert
 
-	esClient, err := getKibanaClient(meta.(*ProviderConf))
+	providerConf := meta.(*ProviderConf)
+	esClient, err := getKibanaClient(providerConf)
 	if err != nil {
 		return err
 	}
@@ -266,7 +267,8 @@ func resourceElasticsearchKibanaAlertDelete(d *schema.ResourceData, meta interfa
 	id := d.Id()
 	spaceID := ""
 
-	kibanaClient, err := getKibanaClient(meta.(*ProviderConf))
+	providerConf := meta.(*ProviderConf)
+	kibanaClient, err := getKibanaClient(providerConf)
 	if err != nil {
 		return err
 	}
@@ -288,7 +290,8 @@ func resourceElasticsearchKibanaAlertDelete(d *schema.ResourceData, meta interfa
 func resourceElasticsearchPostKibanaAlert(d *schema.ResourceData, meta interface{}) (string, error) {
 	spaceID := ""
 
-	kibanaClient, err := getKibanaClient(meta.(*ProviderConf))
+	providerConf := meta.(*ProviderConf)
+	kibanaClient, err := getKibanaClient(providerConf)
 	if err != nil {
 		return "", err
 	}
@@ -424,14 +427,15 @@ func resourceElasticsearchPutKibanaAlert(d *schema.ResourceData, meta interface{
 }
 
 func resourceElasticsearchKibanaGetVersion(meta interface{}) (*version.Version, error) {
-	esClient, err := getClient(meta.(*ProviderConf))
+	providerConf := meta.(*ProviderConf)
+	esClient, err := getClient(providerConf)
 	if err != nil {
 		return nil, err
 	}
 
-	switch client := esClient.(type) {
+	switch esClient.(type) {
 	case *elastic7.Client:
-		return elastic7GetVersion(client)
+		return version.NewVersion(providerConf.esVersion)
 	default:
 		return nil, fmt.Errorf("Kibana Alert endpoint only available from ElasticSearch >= 7.7, got version < 7.0.0")
 	}

--- a/es/util.go
+++ b/es/util.go
@@ -10,13 +10,11 @@ import (
 	"io/ioutil"
 	"log"
 	"os"
-	"reflect"
 	"sort"
 	"strconv"
 	"strings"
 	"unicode"
 
-	"github.com/hashicorp/go-version"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/mitchellh/go-homedir"
@@ -641,15 +639,6 @@ func readPathOrContent(poc string) (string, bool, error) {
 	}
 
 	return poc, false, nil
-}
-
-func elastic7GetVersion(client *elastic7.Client) (*version.Version, error) {
-	urls := reflect.ValueOf(client).Elem().FieldByName("urls")
-	versionString, err := client.ElasticsearchVersion(urls.Index(0).String())
-	if err != nil {
-		return nil, err
-	}
-	return version.NewVersion(versionString)
 }
 
 func toCamelCase(underScored string, startUpperCased bool) (camelCased string) {


### PR DESCRIPTION
Hi, It's me again.

Currently, we are facing an issue when creating index templates in an AWS OpenSearch cluster (compatibility mode disabled).
According to the [docs](https://opensearch.org/faq/#q1.1), OpenSearch is basically a fork of  Elasticsearch/Kibana v7.10.2. 

As a result we set the `elasticsearch_version` in the provider configuration.
At this point everything is working as expected excepts of creating `elasticsearch_composable_index_template` resources.

```
provider "elasticsearch" {
  url                   = "https://..."
  aws_region            = "eu-central-1"
  elasticsearch_version = "7.10.2"
}

resource "elasticsearch_composable_index_template" "template_1" {
  name = "template_1"
  body = "{ ... }"
}
```

```
elasticsearch_composable_index_template.template_1: Creating...
╷
│ Error: ElasticSearch version 1.0.0 is older than 6.0.0 and is not supported.
│ 
│   with elasticsearch_composable_index_template.template_1,
│   on main.tf line 19, in resource "elasticsearch_composable_index_template" "template_1":
│   19: resource "elasticsearch_composable_index_template" "template_1" {
│ 
╵
```

This only happens because the version is checked again before the resource is created, which is actually not necessary.
Additionally, the proposed change would fix the issue #218.