### PR TITLE
Documentation: Specify languages for syntax highlighting

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ resource "elasticsearch_kibana_object" "test_dashboard" {
 
 Example watches (target notification actions must be setup manually before hand)
 
-```
+```hcl
 # Monitor cluster status with auth being required
 resource "elasticsearch_xpack_watch" "cluster-status-red" {
   watch_id = "cluster-status-red"
@@ -282,7 +282,7 @@ Please see [the documentation](./docs/index.md#AWS-authentication) for details.
 * [Golang](https://golang.org/dl/) >= 1.13
 
 
-```
+```sh
 go build -o /path/to/binary/terraform-provider-elasticsearch
 ```
 

--- a/docs/guides/rollover.md
+++ b/docs/guides/rollover.md
@@ -13,7 +13,7 @@ For example, using ILM:
 
 1. Create the following `main.tf` file:
 
-```
+```hcl
 provider "elasticsearch" {
   url = "http://localhost:9200"
 }
@@ -73,7 +73,7 @@ resource "elasticsearch_index" "test" {
 
 2. Start a new Elasticsearch Container:
 
-```
+```sh
 $ export ES_OSS_IMAGE=elasticsearch:7.9.2
 $ docker-compose up -d elasticsearch
 Creating network "terraform-provider-elasticsearch_default" with the default driver
@@ -82,7 +82,7 @@ Creating terraform-provider-elasticsearch_elasticsearch_1 ... done
 
 3. Create the example Index Lifecycle Policy, Index Template and Index:
 
-```
+```sh
 $ terraform apply -auto-approve
 elasticsearch_xpack_index_lifecycle_policy.test: Creating...
 elasticsearch_xpack_index_lifecycle_policy.test: Creation complete after 0s [id=test]
@@ -96,14 +96,14 @@ Apply complete! Resources: 3 added, 0 changed, 0 destroyed.
 
 4. Manually rollover the example index:
 
-```
+```sh
 $ curl -X POST http://localhost:9200/test/_rollover
 {"acknowledged":true,"shards_acknowledged":true,"old_index":"test-000001","new_index":"test-000002","rolled_over":true,"dry_run":false,"conditions":{}}
 ```
 
 5. Delete the initial created index:
 
-```
+```sh
 $ curl -X DELETE http://localhost:9200/test-000001
 {"acknowledged":true}
 ```

--- a/docs/resources/opendistro_ism_policy.md
+++ b/docs/resources/opendistro_ism_policy.md
@@ -45,7 +45,7 @@ The following attributes are exported:
 
 Elasticsearch Open Distro ISM policy can be imported using the `policy_id`, e.g.
 
-```
+```sh
 $ terraform import elasticsearch_opendistro_ism_policy.cleanup delete_after_15d
 ```
 

--- a/docs/resources/opendistro_kibana_tenant.md
+++ b/docs/resources/opendistro_kibana_tenant.md
@@ -41,7 +41,7 @@ The following attributes are exported:
 
 Elasticsearch Open Distro tenant can be imported using the `tenant_name`, e.g.
 
-```
+```sh
 $ terraform import elasticsearch_opendistro_kibana_tenant.writer test
 ```
 

--- a/docs/resources/opendistro_monitor.md
+++ b/docs/resources/opendistro_monitor.md
@@ -104,7 +104,7 @@ The following attributes are exported:
 
 Elasticsearch Open Distro monitor can be imported using the `id`, e.g.
 
-```
+```sh
 $ terraform import elasticsearch_opendistro_monitor.alert lgOZb3UB96pyyRQv0ppQ
 ```
 

--- a/docs/resources/opendistro_role.md
+++ b/docs/resources/opendistro_role.md
@@ -96,7 +96,7 @@ The following attributes are exported:
 
 Elasticsearch Open Distro security role can be imported using the `role_name`, e.g.
 
-```
+```sh
 $ terraform import elasticsearch_opendistro_role.writer logs_writer
 ```
 

--- a/docs/resources/opendistro_roles_mapping.md
+++ b/docs/resources/opendistro_roles_mapping.md
@@ -53,7 +53,7 @@ The following attributes are exported:
 
 Elasticsearch Open Distro security role mapping can be imported using the `role_name`, e.g.
 
-```
+```sh
 $ terraform import elasticsearch_opendistro_roles_mapping.mapper logs_writer
 ```
 

--- a/docs/resources/opendistro_user.md
+++ b/docs/resources/opendistro_user.md
@@ -74,7 +74,7 @@ The following attributes are exported:
 
 Elasticsearch Open Distro user can be imported using the `username`, e.g.
 
-```
+```sh
 $ terraform import elasticsearch_opendistro_user.reader app_reader
 ```
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -9,7 +9,7 @@ the example's own directory.
 
 For example:
 
-```
+```sh
 $ git clone https://github.com/phillbaker/terraform-provider-elasticsearch
 $ cd terraform-provider-elasticsearch/examples/ingest_pipeline
 $ terraform apply


### PR DESCRIPTION
# Summary of  changes
Added a language to every code blocks that haven't been specified.

# Detail
I noticed that some code blocks on the documents have been broken due to the lack of language settings. I added them to all the code blocks that doesn't have language settings for syntax highlighting.

## e.g [Manage indices using rollover and templates](https://registry.terraform.io/providers/phillbaker/elasticsearch/latest/docs/guides/rollover)  

### Before: 
<img width="688" alt="Screen Shot 2022-04-16 at 22 31 42" src="https://user-images.githubusercontent.com/11995398/163676857-2a435c21-e80b-4dc6-90ce-ef0872198448.png">

### After: (on [the Doc Preview Tool](https://registry.terraform.io/tools/doc-preview))
<img width="715" alt="Screen Shot 2022-04-16 at 22 37 21" src="https://user-images.githubusercontent.com/11995398/163677049-73ff43e5-75be-487a-9034-5fc1265e8816.png">

----

I noticed that this repository is using variety of syntax languages for .tf files, [terraform](https://github.com/phillbaker/terraform-provider-elasticsearch/blob/b3995de14289dfb9a754f1c18c0c8881fa4ad742/docs/resources/xpack_snapshot_lifecycle_policy.md?plain=1#L14), [tf](https://github.com/phillbaker/terraform-provider-elasticsearch/blob/eeff3b65d396ea460eb1f6a11f26c9aa5dc4e187/docs/index.md?plain=1#L19), and [hcl](https://github.com/phillbaker/terraform-provider-elasticsearch/blob/2cbf4b515cd1a845ad6936c6d13031482bfd55c4/docs/resources/opendistro_user.md?plain=1#L15).
Because the official repository ([hashicorp/terraform](https://github.com/hashicorp/terraform)) is using `hcl` for the terraform code blocks, I chose `hcl` this time. But I haven't changed the places where already have been specified as `terraform` or `tf` since it's also working properly. Please let me know if you want me to change all places, I'd be happy to do that.