### PR TITLE
xpack role rename should force recreation

### DIFF
--- a/es/resource_elasticsearch_xpack_role.go
+++ b/es/resource_elasticsearch_xpack_role.go
@@ -23,6 +23,7 @@ func resourceElasticsearchXpackRole() *schema.Resource {
 			"role_name": {
 				Type:     schema.TypeString,
 				Required: true,
+				ForceNew: true,
 			},
 			"indices": {
 				Type:     schema.TypeSet,


### PR DESCRIPTION
When Kibana xpack roles are renamed they should be recreated. The current behaviour leads to two roles being present, one with the old name and one with the new name. This causes issues with role mappings and noise in TF plans.