### PR TITLE
improve elasticsearch_opensearch_user example password + description

### DIFF
--- a/docs/resources/opensearch_user.md
+++ b/docs/resources/opensearch_user.md
@@ -16,7 +16,7 @@ Provides an Elasticsearch OpenSearch security user. Please refer to the OpenSear
 # Create a user
 resource "elasticsearch_opensearch_user" "mapper" {
   username    = "app-reader"
-  password    = "supersekret123!"
+  password    = "SuperSekret123!"
   description = "a reader role for our app"
 }
 ```
@@ -58,6 +58,10 @@ The following arguments are supported:
     (Optional) A list of backend roles.
 * `password` -
     (Optional) The plain text password for the user, cannot be specified with `password_hash`.
+    Some implementations may enforce a password policy. Invalid passwords may cause a non-descriptive
+    HTTP 400 Bad Request error. For AWS Elasticsearch domains "password must be at least 8 characters
+    long and contain at least one uppercase letter, one lowercase letter, one digit, and one special
+    character".
 * `password_hash` -
     (Optional) The pre-hashed password for the user, cannot be specified with `password`.
 * `attributes` -


### PR DESCRIPTION
Using example from https://registry.terraform.io/providers/phillbaker/elasticsearch/latest/docs/resources/opensearch_user:

```
# Create a user
resource "elasticsearch_opensearch_user" "mapper" {
  username    = "app-reader"
  password    = "supersekret123!"
  description = "a reader role for our app"
}
```

... fails on AWS ES domain with non-descriptive error:

```
Error: elastic: Error 400 (Bad Request)
```

To debug I changed the provider URL to a netcat listener to catch the request. On replay on ES domain I got this error:
```
{
  "status": "error",
  "reason": "Password must be at least 8 characters long and contain at least one uppercase letter, one lowercase letter, one digit, and one special character."
}
```

The password in the example does not have upper case characters, so I suggest a documentation fix.

I will leave it up to the maintainers to decide if additional logic is needed to return an actionable error.