### PR TITLE
Changes go mod to match with major version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/phillbaker/terraform-provider-elasticsearch
+module github.com/phillbaker/terraform-provider-elasticsearch/v2
 
 go 1.14
 


### PR DESCRIPTION
This allows to import the newest package version in other go packages.

Fixes: `github.com/phillbaker/terraform-provider-elasticsearch@v2.0.4: invalid version: module contains a go.mod file, so module path must match major version ("github.com/phillbaker/terraform-provider-elasticsearch/v2")`  when doing `go list -m github.com/phillbaker/terraform-provider-elasticsearch@v2.0.4`