### PR TITLE
Allow provider to use the external ID when assuming the role in the p…

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -63,6 +63,7 @@ The following arguments are supported:
 * `username` (Optional) - Username to use to connect to elasticsearch using basic auth. Defaults to `ELASTICSEARCH_USERNAME` from the environment
 * `password` (Optional) - Password to use to connect to elasticsearch using basic auth. Defaults to `ELASTICSEARCH_PASSWORD` from the environment
 * `aws_assume_role_arn` (Optional) - ARN of role to assume when using AWS Elasticsearch Service domains.
+* `aws_assume_role_external_id` (Optional) - External ID configured in the IAM policy of the IAM Role to assume prior to using AWS Elasticsearch Service domains.
 * `aws_assume_role_session_name` - AWS IAM session name to use when assuming a role.
 * `aws_access_key` (Optional) - The access key for use with AWS Elasticsearch Service domains. It can also be sourced from the `AWS_ACCESS_KEY_ID` environment variable.
 * `aws_secret_key` (Optional) - The secret key for use with AWS Elasticsearch Service domains. It can also be sourced from the `AWS_SECRET_ACCESS_KEY` environment variable.
@@ -109,13 +110,15 @@ provider "elasticsearch" {
 #### Assume role configuration
 
 You can instruct the provider to assume a role in AWS before interacting with the cluster by setting the `aws_assume_role_arn` variable.
+Optionnaly, you can configure the [External ID](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_create_for-user_externalid.html) of IAM role trust policy by setting the `aws_assume_role_external_id` variable.
 
 Example usage:
 
 ```tf
 provider "elasticsearch" {
-    url                 = "https://search-foo-bar-pqrhr4w3u4dzervg41frow4mmy.us-east-1.es.amazonaws.com"
-    aws_assume_role_arn = "arn:aws:iam::012345678901:role/rolename"
+    url                         = "https://search-foo-bar-pqrhr4w3u4dzervg41frow4mmy.us-east-1.es.amazonaws.com"
+    aws_assume_role_arn         = "arn:aws:iam::012345678901:role/rolename"
+    aws_assume_role_external_id = "Unique ID Assigned by Example Corp"
 }
 ```
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -118,7 +118,7 @@ Example usage:
 provider "elasticsearch" {
     url                         = "https://search-foo-bar-pqrhr4w3u4dzervg41frow4mmy.us-east-1.es.amazonaws.com"
     aws_assume_role_arn         = "arn:aws:iam::012345678901:role/rolename"
-    aws_assume_role_external_id = "Unique ID Assigned by Example Corp"
+    aws_assume_role_external_id = "Unique ID"
 }
 ```
 

--- a/es/provider_test.go
+++ b/es/provider_test.go
@@ -216,13 +216,15 @@ func TestAWSCredsAssumeRole(t *testing.T) {
 	testRegion := "us-east-1"
 
 	testConfig := map[string]interface{}{
-		"aws_assume_role_arn": "test_arn",
+		"aws_assume_role_arn":         "test_arn",
+		"aws_assume_role_external_id": "secret_id",
 	}
 
 	testConfigData := schema.TestResourceDataRaw(t, Provider().Schema, testConfig)
 
 	conf := &ProviderConf{
-		awsAssumeRoleArn: testConfigData.Get("aws_assume_role_arn").(string),
+		awsAssumeRoleArn:        testConfigData.Get("aws_assume_role_arn").(string),
+		awsAssumeRoleExternalID: testConfigData.Get("aws_assume_role_external_id").(string),
 	}
 	s := awsSession(testRegion, conf)
 	if s == nil {


### PR DESCRIPTION
…rovider configuration set up
Description

The provider needs the external ID configured in the condition of the IAM policy if it's set in the role iam policy when using assume role configuration
Issues Resolved

Close issue https://github.com/phillbaker/terraform-provider-elasticsearch/issues/346
