### PR TITLE
Fix typos

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -98,7 +98,7 @@ jobs:
         key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
         restore-keys: ${{ runner.os }}-go-
     - name: Run Docker containers
-      run: docker-compose up --detach
+      run: docker compose up --detach
       env:
         OSS_IMAGE: "${{ matrix.oss-image }}:${{ matrix.version }}"
         ES_COMMAND: "${{matrix.ES_COMMAND}}"

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,5 +1,6 @@
 # Visit https://goreleaser.com for documentation on how to customize this
 # behavior.
+version: 2
 before:
   hooks:
     - go mod tidy

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -34,7 +34,7 @@ checksum:
 signs:
   - artifacts: checksum
     args:
-      # pass the batch flag to indicate its not interactive.
+      # pass the batch flag to indicate it's not interactive.
       - "--batch"
       - "--local-user"
       - "{{ .Env.GPG_FINGERPRINT }}"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -98,7 +98,7 @@
 
 ### Added
 - [index] Add include_type_name for compatibility between ESv6/7
-- [xpack license] Handle ackowledged only reponse.
+- [xpack license] Handle acknowledged only response.
 - [kibana alert] Fix storing actions, missing descriptions.
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -299,8 +299,8 @@ export ES_KIBANA_IMAGE=""
 export OPENSEARCH_PREFIX="plugins.security"
 export OSS_ENV_VAR="plugins.security.disabled=true"
 export XPACK_IMAGE="docker.elastic.co/elasticsearch/elasticsearch:7.10.1"
-docker-compose up -d
-docker-compose ps -a
+docker compose up -d
+docker compose ps -a
 ```
 
 When running tests, ensure that your test/debug profile has environmental variables as below:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,7 +5,7 @@ services:
     image: ${OSS_IMAGE}
     hostname: elasticsearch
     container_name: elasticsearch
-    networks: 
+    networks:
       - elasticsearch # used by ESv6 kibana
     environment:
       - cluster.name=elasticsearch
@@ -28,7 +28,7 @@ services:
     ports:
       - 9200:9200
   xpack:
-    image: ${XPACK_IMAGE:-rwgrim/docker-noop}
+    image: ${XPACK_IMAGE:-alpine}
     hostname: elasticsearch-xpack
     container_name: elasticsearch-xpack
     environment:
@@ -55,7 +55,7 @@ services:
     ports:
       - 9210:9210
   opendistro:
-    image: ${ES_OPENDISTRO_IMAGE:-rwgrim/docker-noop}
+    image: ${ES_OPENDISTRO_IMAGE:-alpine}
     hostname: elasticsearch-opendistro
     container_name: elasticsearch-opendistro
     environment:
@@ -79,7 +79,7 @@ services:
     ports:
       - 9220:9220
   xpack-kibana:
-    image: ${XPACK_IMAGE:-rwgrim/docker-noop}
+    image: ${XPACK_IMAGE:-alpine}
     networks:
       - elasticsearch  # used by ESv7 kibana
     environment:
@@ -101,7 +101,7 @@ services:
     ports:
       - 9230:9230
   kibana:
-    image: ${ES_KIBANA_IMAGE:-rwgrim/docker-noop}
+    image: ${ES_KIBANA_IMAGE:-alpine}
     networks:
       - elasticsearch
     links:

--- a/docs/guides/rollover.md
+++ b/docs/guides/rollover.md
@@ -75,7 +75,7 @@ resource "elasticsearch_index" "test" {
 
 ```sh
 $ export ES_OSS_IMAGE=elasticsearch:7.9.2
-$ docker-compose up -d elasticsearch
+$ docker compose up -d elasticsearch
 Creating network "terraform-provider-elasticsearch_default" with the default driver
 Creating terraform-provider-elasticsearch_elasticsearch_1 ... done
 ```

--- a/docs/index.md
+++ b/docs/index.md
@@ -110,7 +110,7 @@ provider "elasticsearch" {
 #### Assume role configuration
 
 You can instruct the provider to assume a role in AWS before interacting with the cluster by setting the `aws_assume_role_arn` variable.
-Optionnaly, you can configure the [External ID](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_create_for-user_externalid.html) of IAM role trust policy by setting the `aws_assume_role_external_id` variable.
+Optionally, you can configure the [External ID](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_create_for-user_externalid.html) of IAM role trust policy by setting the `aws_assume_role_external_id` variable.
 
 Example usage:
 

--- a/docs/resources/cluster_settings.md
+++ b/docs/resources/cluster_settings.md
@@ -34,7 +34,7 @@ resource "elasticsearch_cluster_settings" "global" {
 - **cluster_max_shards_per_node_frozen** (Number) The total number of primary and replica frozen shards, for the cluster; Ssards for closed indices do not count toward this limit, a cluster with no frozen data nodes is unlimited.
 - **cluster_no_master_block** (String) Specifies which operations are rejected when there is no active master in a cluster (all, write)
 - **cluster_persistent_tasks_allocation_enable** (String) Whether allocation for persistent tasks is active (all, none)
-- **cluster_persistent_tasks_allocation_recheck_interval** (String) A time string controling how often assignment checks are performed to react to whether persistent tasks can be assigned to nodes
+- **cluster_persistent_tasks_allocation_recheck_interval** (String) A time string controlling how often assignment checks are performed to react to whether persistent tasks can be assigned to nodes
 - **cluster_routing_allocation_allow_rebalance** (String) Specify when shard rebalancing is allowed (always, indices_primaries_active, indices_all_active)
 - **cluster_routing_allocation_awareness_attributes** (String) Use custom node attributes to take hardware configuration into account when allocating shards
 - **cluster_routing_allocation_balance_index** (Number) Weight factor for the number of shards per index allocated on a node, increasing this raises the tendency to equalize the number of shards per index across all nodes
@@ -55,7 +55,7 @@ resource "elasticsearch_cluster_settings" "global" {
 - **cluster_routing_rebalance_enable** (String) Allow rebalancing for specific kinds of shards (all, primaries, replicas, none)
 - **indices_breaker_fielddata_limit** (String) The percentage of memory above which if loading a field into the field data cache would cause the cache to exceed this limit, an error is returned
 - **indices_breaker_fielddata_overhead** (Number) A constant that all field data estimations are multiplied by
-- **indices_breaker_request_limit** (String) The percentabge of memory above which per-request data structures (e.g. calculating aggregations) are prevented from exceeding
+- **indices_breaker_request_limit** (String) The percentage of memory above which per-request data structures (e.g. calculating aggregations) are prevented from exceeding
 - **indices_breaker_request_overhead** (Number) A constant that all request estimations are multiplied by
 - **indices_breaker_total_limit** (String) The percentage of total amount of memory that can be used across all breakers
 - **indices_recovery_max_bytes_per_sec** (String) Maximum total inbound and outbound recovery traffic for each node, in mb

--- a/docs/resources/opensearch_audit_config.md
+++ b/docs/resources/opensearch_audit_config.md
@@ -10,10 +10,10 @@ description: |-
 
 Audit config lets you configure the security plugin audit log settings. See the guide https://opensearch.org/docs/latest/security-plugin/audit-logs/index/ and AWS specific information https://docs.aws.amazon.com/opensearch-service/latest/developerguide/audit-logs.html.
 
-Note that when using with a managed AWS OpenSearch cluster, some values and  permutations are not 
-allowed, and will result in a HTTP 409 (Conflict) error being returned. See the comments in the 
-example below for some know scenario's where this may occur.
-  
+Note that when using with a managed AWS OpenSearch cluster, some values and  permutations are not
+allowed, and will result in a HTTP 409 (Conflict) error being returned. See the comments in the
+example below for some known scenarios where this may occur.
+
 ## Example Usage
 
 ```terraform

--- a/docs/resources/opensearch_ism_policy_mapping.md
+++ b/docs/resources/opensearch_ism_policy_mapping.md
@@ -53,6 +53,6 @@ Optional:
 Import is supported using the following syntax:
 
 ```shell
-# Import by poilcy_id
+# Import by policy_id
 terraform import elasticsearch_opensearch_ism_policy_mapping.test policy_1
 ```

--- a/docs/resources/script.md
+++ b/docs/resources/script.md
@@ -26,7 +26,7 @@ resource "elasticsearch_script" "test_script" {
 The following arguments are supported:
 
 * `script_id` - (Required) The name of the script.
-* `lang` - Specifies the language the script is written in. Defaults to painless..
+* `lang` - Specifies the language the script is written in. Defaults to painless.
 * `source` - (Required) The source of the stored script.
 
 ## Attributes Reference

--- a/docs/resources/xpack_role_mapping.md
+++ b/docs/resources/xpack_role_mapping.md
@@ -46,7 +46,7 @@ resource "elasticsearch_xpack_role_mapping" "test" {
 
 - **role_mapping_name** (String) The distinct name that identifies the role mapping, used solely as an identifier.
 - **roles** (Set of String) A list of role names that are granted to the users that match the role mapping rules.
-- **rules** (String) A list of mustache templates that will be evaluated to determine the roles names that should granted to the users that match the role mapping rules. This matches fields of users, rules can be grouped into `all` and `any` top level keys.
+- **rules** (String) A list of mustache templates that will be evaluated to determine the roles names that should be granted to the users that match the role mapping rules. This matches fields of users, rules can be grouped into `all` and `any` top level keys.
 
 ### Optional
 

--- a/docs/resources/xpack_user.md
+++ b/docs/resources/xpack_user.md
@@ -33,7 +33,7 @@ resource "elasticsearch_xpack_user" "test" {
 ### Required
 
 - **roles** (Set of String) A set of roles the user has. The roles determine the user’s access permissions
-- **username** (String) An identifier for the user. 
+- **username** (String) An identifier for the user.
 
  Usernames must be at least 1 and no more than 1024 characters. They can contain alphanumeric characters (a-z, A-Z, 0-9), spaces, punctuation, and printable symbols in the Basic Latin (ASCII) block. Leading or trailing whitespace is not allowed.
 

--- a/es/data_source_elasticsearch_host.go
+++ b/es/data_source_elasticsearch_host.go
@@ -34,7 +34,7 @@ func dataSourceElasticsearchHostRead(d *schema.ResourceData, m interface{}) erro
 
 	// The upstream elastic client does not export the property for the urls
 	// it's using. Presumably the URLS would be available where the client is
-	// intantiated, but in terraform, that's not always practicable.
+	// instantiated, but in terraform, that's not always practicable.
 	var err error
 	esClient, err := getClient(m.(*ProviderConf))
 	if err != nil {

--- a/es/data_source_elasticsearch_opendistro_destination.go
+++ b/es/data_source_elasticsearch_opendistro_destination.go
@@ -20,7 +20,7 @@ var datasourceOpenDistroDestinationSchema = map[string]*schema.Schema{
 	"name": {
 		Type:        schema.TypeString,
 		Required:    true,
-		Description: "Name of the destrination to retrieve",
+		Description: "Name of the destination to retrieve",
 	},
 	"body": {
 		Type:        schema.TypeMap,

--- a/es/resource_elasticsearch_cluster_settings.go
+++ b/es/resource_elasticsearch_cluster_settings.go
@@ -95,7 +95,7 @@ func resourceElasticsearchClusterSettings() *schema.Resource {
 			"cluster_persistent_tasks_allocation_recheck_interval": {
 				Type:        schema.TypeString,
 				Optional:    true,
-				Description: "A time string controling how often assignment checks are performed to react to whether persistent tasks can be assigned to nodes",
+				Description: "A time string controlling how often assignment checks are performed to react to whether persistent tasks can be assigned to nodes",
 			},
 			"cluster_blocks_read_only": {
 				Type:        schema.TypeBool,
@@ -225,7 +225,7 @@ func resourceElasticsearchClusterSettings() *schema.Resource {
 			"indices_breaker_request_limit": {
 				Type:        schema.TypeString,
 				Optional:    true,
-				Description: "The percentabge of memory above which per-request data structures (e.g. calculating aggregations) are prevented from exceeding",
+				Description: "The percentage of memory above which per-request data structures (e.g. calculating aggregations) are prevented from exceeding",
 			},
 			"indices_breaker_request_overhead": {
 				Type:        schema.TypeFloat,

--- a/es/resource_elasticsearch_kibana_alert_test.go
+++ b/es/resource_elasticsearch_kibana_alert_test.go
@@ -26,7 +26,7 @@ func TestAccElasticsearchKibanaAlert(t *testing.T) {
 	}
 	meta := provider.Meta()
 
-	// We use the elasticsearch version to check compatibilty, it'll connect to
+	// We use the elasticsearch version to check compatibility, it'll connect to
 	// kibana below
 	providerConf := meta.(*ProviderConf)
 	esClient, err := getClient(providerConf)
@@ -54,8 +54,8 @@ func TestAccElasticsearchKibanaAlert(t *testing.T) {
 	}
 
 	testConfig := testAccElasticsearchKibanaAlertV77(defaultActionID)
-	testParmsConfig := testAccElasticsearchKibanaAlertParamsJSONV77
-	testActionParmsConfig := testAccElasticsearchKibanaAlertJsonV77(defaultActionID)
+	testParamsConfig := testAccElasticsearchKibanaAlertParamsJSONV77
+	testActionParamsConfig := testAccElasticsearchKibanaAlertJsonV77(defaultActionID)
 	elasticVersion, err := resourceElasticsearchKibanaGetVersion(meta)
 	if err != nil {
 		t.Skipf("err: %s", err)
@@ -67,8 +67,8 @@ func TestAccElasticsearchKibanaAlert(t *testing.T) {
 	}
 	if elasticVersion.GreaterThanOrEqual(versionV711) {
 		testConfig = testAccElasticsearchKibanaAlertV711
-		testParmsConfig = testAccElasticsearchKibanaAlertParamsJSONV711
-		testActionParmsConfig = testAccElasticsearchKibanaAlertJsonV711(defaultActionID)
+		testParamsConfig = testAccElasticsearchKibanaAlertParamsJSONV711
+		testActionParamsConfig = testAccElasticsearchKibanaAlertJsonV711(defaultActionID)
 	}
 
 	log.Printf("[INFO] TestAccElasticsearchKibanaAlert %+v", elasticVersion)
@@ -89,13 +89,13 @@ func TestAccElasticsearchKibanaAlert(t *testing.T) {
 				),
 			},
 			{
-				Config: testParmsConfig,
+				Config: testParamsConfig,
 				Check: resource.ComposeTestCheckFunc(
 					testCheckElasticsearchKibanaAlertExists("elasticsearch_kibana_alert.test_params_json"),
 				),
 			},
 			{
-				Config: testActionParmsConfig,
+				Config: testActionParamsConfig,
 				Check: resource.ComposeTestCheckFunc(
 					testCheckElasticsearchKibanaAlertExists("elasticsearch_kibana_alert.test_action_json"),
 				),

--- a/es/resource_elasticsearch_opendistro_ism_policy_test.go
+++ b/es/resource_elasticsearch_opendistro_ism_policy_test.go
@@ -14,7 +14,7 @@ import (
 )
 
 func TestAccElasticsearchOpenDistroISMPolicy(t *testing.T) {
-	opensearchVerionConstraints, _ := version.NewConstraint(">= 1.1, < 6")
+	opensearchVersionConstraints, _ := version.NewConstraint(">= 1.1, < 6")
 	provider := Provider()
 	diags := provider.Configure(context.Background(), &terraform.ResourceConfig{})
 	if diags.HasError() {
@@ -38,7 +38,7 @@ func TestAccElasticsearchOpenDistroISMPolicy(t *testing.T) {
 		if err != nil {
 			t.Skipf("err: %s", err)
 		}
-		if opensearchVerionConstraints.Check(v) {
+		if opensearchVersionConstraints.Check(v) {
 			config = testAccElasticsearchOpenDistroISMPolicyOpenSearch11
 		} else {
 			config = testAccElasticsearchOpenDistroISMPolicyV7

--- a/es/resource_elasticsearch_opendistro_kibana_tenant.go
+++ b/es/resource_elasticsearch_opendistro_kibana_tenant.go
@@ -56,7 +56,7 @@ func resourceElasticsearchOpenDistroKibanaTenant() *schema.Resource {
 		Importer: &schema.ResourceImporter{
 			StateContext: schema.ImportStatePassthroughContext,
 		},
-		DeprecationMessage: "elasticsearch_opendistro_kibana_tentant is deprecated, please use elasticsearch_opensearch_kibana_tenant resource instead.",
+		DeprecationMessage: "elasticsearch_opendistro_kibana_tenant is deprecated, please use elasticsearch_opensearch_kibana_tenant resource instead.",
 	}
 }
 

--- a/es/resource_elasticsearch_opendistro_monitor.go
+++ b/es/resource_elasticsearch_opendistro_monitor.go
@@ -68,7 +68,7 @@ func resourceElasticsearchOpenDistroMonitorCreate(d *schema.ResourceData, m inte
 	log.Printf("[INFO] Object ID: %s", d.Id())
 
 	// Although we receive the full monitor in the response to the POST,
-	// OpenDistro seems to add default values to the ojbect after the resource
+	// OpenDistro seems to add default values to the object after the resource
 	// is saved, e.g. adjust_pure_negative, boost values
 	return resourceElasticsearchOpenDistroMonitorRead(d, m)
 }

--- a/es/resource_elasticsearch_opendistro_monitor_test.go
+++ b/es/resource_elasticsearch_opendistro_monitor_test.go
@@ -13,7 +13,7 @@ import (
 )
 
 func TestAccElasticsearchOpenDistroMonitor(t *testing.T) {
-	opensearchVerionConstraints, _ := version.NewConstraint(">= 1.1, < 6")
+	opensearchVersionConstraints, _ := version.NewConstraint(">= 1.1, < 6")
 	var config string
 	var check resource.TestCheckFunc
 	meta := testAccOpendistroProvider.Meta()
@@ -21,7 +21,7 @@ func TestAccElasticsearchOpenDistroMonitor(t *testing.T) {
 	if err != nil {
 		t.Fatalf("err: %s", err)
 	}
-	if opensearchVerionConstraints.Check(v) {
+	if opensearchVersionConstraints.Check(v) {
 		config = testAccElasticsearchOpenDistroMonitorOpenSearch11
 		check = resource.ComposeTestCheckFunc(
 			testCheckElasticsearchOpenDistroMonitorExists("elasticsearch_opendistro_monitor.test_monitor1"),

--- a/es/resource_elasticsearch_opendistro_role.go
+++ b/es/resource_elasticsearch_opendistro_role.go
@@ -276,11 +276,11 @@ func resourceElasticsearchPutOpenDistroRole(d *schema.ResourceData, m interface{
 	}
 	var tenantPermissionsBody []TenantPermissions
 	for _, tenant := range tenantPermissions {
-		putTeanant := TenantPermissions{
+		putTenant := TenantPermissions{
 			TenantPatterns: tenant.TenantPatterns,
 			AllowedActions: tenant.AllowedActions,
 		}
-		tenantPermissionsBody = append(tenantPermissionsBody, putTeanant)
+		tenantPermissionsBody = append(tenantPermissionsBody, putTenant)
 	}
 
 	rolesDefinition := RoleBody{
@@ -317,7 +317,7 @@ func resourceElasticsearchPutOpenDistroRole(d *schema.ResourceData, m interface{
 			// see https://github.com/opendistro-for-
 			// elasticsearch/security/issues/1095, this should return a 409, but
 			// retry on the 500 as well. We can't parse the message to only retry on
-			// the conlict exception becaues the elastic client doesn't directly
+			// the conflict exception because the elastic client doesn't directly
 			// expose the error response body
 			RetryStatusCodes: []int{http.StatusConflict, http.StatusInternalServerError},
 			Retrier: elastic7.NewBackoffRetrier(

--- a/es/resource_elasticsearch_opendistro_roles_mapping.go
+++ b/es/resource_elasticsearch_opendistro_roles_mapping.go
@@ -241,7 +241,7 @@ func resourceElasticsearchPutOpenDistroRolesMapping(d *schema.ResourceData, m in
 			// see https://github.com/opendistro-for-
 			// elasticsearch/security/issues/1095, this should return a 409, but
 			// retry on the 500 as well. We can't parse the message to only retry on
-			// the conlict exception becaues the elastic client doesn't directly
+			// the conflict exception because the elastic client doesn't directly
 			// expose the error response body
 			RetryStatusCodes: []int{http.StatusConflict, http.StatusInternalServerError},
 			Retrier: elastic7.NewBackoffRetrier(

--- a/es/resource_elasticsearch_opendistro_user.go
+++ b/es/resource_elasticsearch_opendistro_user.go
@@ -234,7 +234,7 @@ func resourceElasticsearchPutOpenDistroUser(d *schema.ResourceData, m interface{
 			// see https://github.com/opendistro-for-
 			// elasticsearch/security/issues/1095, this should return a 409, but
 			// retry on the 500 as well. We can't parse the message to only retry on
-			// the conlict exception becaues the elastic client doesn't directly
+			// the conflict exception because the elastic client doesn't directly
 			// expose the error response body
 			RetryStatusCodes: []int{http.StatusConflict, http.StatusInternalServerError},
 			Retrier: elastic7.NewBackoffRetrier(

--- a/es/resource_elasticsearch_xpack_license.go
+++ b/es/resource_elasticsearch_xpack_license.go
@@ -215,13 +215,13 @@ func resourceElasticsearchPutEnterpriseLicense(l string, meta interface{}) (Lice
 	}
 
 	if !licenseResponse.Acknowledged {
-		return emptyLicense, errors.New("License waas not acknowledged")
+		return emptyLicense, errors.New("License was not acknowledged")
 	}
 
 	if len(licenseResponse.Licenses) > 0 {
 		return licenseResponse.Licenses[0], err
 	} else {
-		// The API can ackowledge a license, but not return it :|, so we parse what we PUTed
+		// The API can acknowledge a license, but not return it :|, so we parse what we PUTed
 		var license License
 		if err := json.Unmarshal([]byte(l), &license); err != nil {
 			return emptyLicense, fmt.Errorf("Error unmarshalling license: %+v: %+v", err, body)

--- a/es/resource_elasticsearch_xpack_license_test.go
+++ b/es/resource_elasticsearch_xpack_license_test.go
@@ -15,7 +15,7 @@ import (
 )
 
 // Note the tests run with a trial license enabled, so this test is
-// "destructive" in that once deactivated, a trail license may not be re-
+// "destructive" in that once deactivated, a trial license may not be re-
 // activated. Restarting the docker compose container doesn't seem to work.
 func TestAccElasticsearchXpackLicense_Basic(t *testing.T) {
 	resource.Test(t, resource.TestCase{

--- a/es/resource_elasticsearch_xpack_role_mapping.go
+++ b/es/resource_elasticsearch_xpack_role_mapping.go
@@ -36,7 +36,7 @@ func resourceElasticsearchXpackRoleMapping() *schema.Resource {
 				Type:             schema.TypeString,
 				Required:         true,
 				DiffSuppressFunc: suppressEquivalentJson,
-				Description:      "A list of mustache templates that will be evaluated to determine the roles names that should granted to the users that match the role mapping rules. This matches fields of users, rules can be grouped into `all` and `any` top level keys.",
+				Description:      "A list of mustache templates that will be evaluated to determine the roles names that should be granted to the users that match the role mapping rules. This matches fields of users, rules can be grouped into `all` and `any` top level keys.",
 			},
 			"roles": {
 				Type: schema.TypeSet,

--- a/examples/resources/elasticsearch_opensearch_ism_policy_mapping/import.sh
+++ b/examples/resources/elasticsearch_opensearch_ism_policy_mapping/import.sh
@@ -1,2 +1,2 @@
-# Import by poilcy_id
+# Import by policy_id
 terraform import elasticsearch_opensearch_ism_policy_mapping.test policy_1

--- a/test_aws_config
+++ b/test_aws_config
@@ -1,3 +1,3 @@
 [profile testing]
 aws_access_key_id = PROFILE_ACCESS_KEY
-aws_secret_access_key = PROFILE_SECRET_KEY 
+aws_secret_access_key = PROFILE_SECRET_KEY


### PR DESCRIPTION
Just thought I'd contribute some typo fixes, nothing controversial (hopefully).

Use the following command to get a quick and dirty summary of the specific corrections made:
```shell
git diff HEAD^! --word-diff-regex='\w+' -U0 \
  | grep -E '\[\-.*\-\]\{\+.*\+\}' \
  | sed -r 's/.*\[\-(.*)\-\]\{\+(.*)\+\}.*/\1 \2/' \
  | sort | uniq -c | sort -n
```

FWIW, the top typos are:
* parms (6)
* verion (4)
* becaues (3)
* controling (2)
* percentabge (2)
* poilcy (2)
* teanant (2)